### PR TITLE
Add battery percentage display option in menu bar icon

### DIFF
--- a/Stasis/DefaultsKeys.swift
+++ b/Stasis/DefaultsKeys.swift
@@ -11,6 +11,10 @@ extension Defaults.Keys {
     // Status Icon
     static let showBatteryPercentageInStatusIcon = Key<Bool>(
         "showBatteryPercentageInStatusIcon", default: false)
+    static let showBatteryPercentageInsideIconOnBattery = Key<Bool>(
+        "showBatteryPercentageInsideIconOnBattery", default: false)
+    static let showBatteryPercentageOutsideIconWhenPowered = Key<Bool>(
+        "showBatteryPercentageOutsideIconWhenPowered", default: true)
     static let showBatteryStateInStatusIcon = Key<Bool>(
         "showBatteryStateInStatusIcon", default: true)
 

--- a/Stasis/DefaultsKeys.swift
+++ b/Stasis/DefaultsKeys.swift
@@ -5,9 +5,9 @@ import smc_power
 extension MagSafeLEDState: Defaults.Serializable {}
 
 enum PercentageDisplayLocation: String, Defaults.Serializable, CaseIterable, Identifiable {
-    case hidden = "Hidden"
-    case nextToIcon = "Next to Icon"
-    case insideIcon = "Inside Icon"
+    case hidden
+    case nextToIcon
+    case insideIcon
 
     var id: String { rawValue }
 }

--- a/Stasis/DefaultsKeys.swift
+++ b/Stasis/DefaultsKeys.swift
@@ -18,7 +18,7 @@ extension Defaults.Keys {
 
     // Status Icon
     static let batteryPercentageDisplayLocation = Key<PercentageDisplayLocation>(
-        "batteryPercentageDisplayLocation", default: .hidden)
+        "batteryPercentageDisplayLocation", default: .nextToIcon)
     static let showBatteryStateInStatusIcon = Key<Bool>(
         "showBatteryStateInStatusIcon", default: true)
 

--- a/Stasis/DefaultsKeys.swift
+++ b/Stasis/DefaultsKeys.swift
@@ -4,17 +4,21 @@ import smc_power
 
 extension MagSafeLEDState: Defaults.Serializable {}
 
+enum PercentageDisplayLocation: String, Defaults.Serializable, CaseIterable, Identifiable {
+    case hidden = "Hidden"
+    case nextToIcon = "Next to Icon"
+    case insideIcon = "Inside Icon"
+
+    var id: String { rawValue }
+}
+
 extension Defaults.Keys {
     // General
     static let launchAtLogin = Key<Bool>("launchAtLogin", default: false)
 
     // Status Icon
-    static let showBatteryPercentageInStatusIcon = Key<Bool>(
-        "showBatteryPercentageInStatusIcon", default: false)
-    static let showBatteryPercentageInsideIconOnBattery = Key<Bool>(
-        "showBatteryPercentageInsideIconOnBattery", default: false)
-    static let showBatteryPercentageOutsideIconWhenPowered = Key<Bool>(
-        "showBatteryPercentageOutsideIconWhenPowered", default: true)
+    static let batteryPercentageDisplayLocation = Key<PercentageDisplayLocation>(
+        "batteryPercentageDisplayLocation", default: .hidden)
     static let showBatteryStateInStatusIcon = Key<Bool>(
         "showBatteryStateInStatusIcon", default: true)
 

--- a/Stasis/L10n/Localizable.xcstrings
+++ b/Stasis/L10n/Localizable.xcstrings
@@ -1,6 +1,9 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "%lld" : {
+
+    },
     "%lld%%" : {
 
     },
@@ -812,7 +815,11 @@
     "Discharge the battery to your charge limit when plugged in above the target level." : {
 
     },
+    "Display battery percentage next to or inside the menu bar icon." : {
+
+    },
     "Display the current battery percentage next to the status icon in the menu bar." : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -1609,6 +1616,12 @@
       }
     },
     "Show battery state" : {
+
+    },
+    "Show outside percentage when on power" : {
+
+    },
+    "Show percentage inside icon on battery" : {
 
     },
     "Sleep Prevention" : {

--- a/Stasis/L10n/Localizable.xcstrings
+++ b/Stasis/L10n/Localizable.xcstrings
@@ -1,9 +1,6 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
-    "%lld" : {
-
-    },
     "%lld%%" : {
 
     },

--- a/Stasis/L10n/Localizable.xcstrings
+++ b/Stasis/L10n/Localizable.xcstrings
@@ -1413,6 +1413,9 @@
         }
       }
     },
+    "Percentage display location" : {
+
+    },
     "Power" : {
       "localizations" : {
         "de" : {
@@ -1588,6 +1591,7 @@
       }
     },
     "Show battery percentage" : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -1616,12 +1620,6 @@
       }
     },
     "Show battery state" : {
-
-    },
-    "Show outside percentage when on power" : {
-
-    },
-    "Show percentage inside icon on battery" : {
 
     },
     "Sleep Prevention" : {

--- a/Stasis/L10n/Localizable.xcstrings
+++ b/Stasis/L10n/Localizable.xcstrings
@@ -1017,6 +1017,12 @@
         }
       }
     },
+    "Hidden" : {
+
+    },
+    "Inside icon" : {
+
+    },
     "Launch at login" : {
       "localizations" : {
         "de" : {
@@ -1240,6 +1246,9 @@
           }
         }
       }
+    },
+    "Next to icon" : {
+
     },
     "Notifications" : {
       "localizations" : {
@@ -1556,6 +1565,9 @@
       }
     },
     "Show battery state" : {
+
+    },
+    "Show percentage" : {
 
     },
     "Sleep Prevention" : {

--- a/Stasis/L10n/Localizable.xcstrings
+++ b/Stasis/L10n/Localizable.xcstrings
@@ -818,35 +818,6 @@
     "Display battery percentage next to or inside the menu bar icon." : {
 
     },
-    "Display the current battery percentage next to the status icon in the menu bar." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Den aktuellen Batterieprozentsatz neben dem Statussymbol in der Menüleiste anzeigen."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mostrar el porcentaje de batería actual junto al ícono en la barra de menú."
-          }
-        },
-        "es-US" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mostrar el porcentaje de batería actual junto al ícono en la barra de menú."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "メニューバーのステータスアイコンの横にバッテリー残量を表示します。"
-          }
-        }
-      }
-    },
     "Enable heat protection" : {
       "localizations" : {
         "de" : {
@@ -1413,9 +1384,6 @@
         }
       }
     },
-    "Percentage display location" : {
-
-    },
     "Power" : {
       "localizations" : {
         "de" : {
@@ -1586,35 +1554,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "設定"
-          }
-        }
-      }
-    },
-    "Show battery percentage" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Batterieprozentsatz anzeigen"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mostrar porcentaje de batería"
-          }
-        },
-        "es-US" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mostrar porcentaje de batería"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "バッテリー残量を表示"
           }
         }
       }

--- a/Stasis/StatusBarManager.swift
+++ b/Stasis/StatusBarManager.swift
@@ -43,6 +43,8 @@ class StatusBarManager {
 struct StatusBarContentView: View {
     let viewModel: MenuViewModel
     @Default(.showBatteryPercentageInStatusIcon) var showPercentage
+    @Default(.showBatteryPercentageInsideIconOnBattery) var showPercentageInsideIconOnBattery
+    @Default(.showBatteryPercentageOutsideIconWhenPowered) var showPercentageOutsideIconWhenPowered
     @Default(.showBatteryStateInStatusIcon) var showState
 
     var body: some View {
@@ -51,6 +53,8 @@ struct StatusBarContentView: View {
             chargingMode: viewModel.chargingMode,
             isLowPowerModeEnabled: viewModel.isLowPowerModeEnabled,
             showPercentage: showPercentage,
+            showPercentageInsideIconOnBattery: showPercentageInsideIconOnBattery,
+            showPercentageOutsideIconWhenPowered: showPercentageOutsideIconWhenPowered,
             showState: showState
         )
         .fixedSize()

--- a/Stasis/StatusBarManager.swift
+++ b/Stasis/StatusBarManager.swift
@@ -42,9 +42,7 @@ class StatusBarManager {
 
 struct StatusBarContentView: View {
     let viewModel: MenuViewModel
-    @Default(.showBatteryPercentageInStatusIcon) var showPercentage
-    @Default(.showBatteryPercentageInsideIconOnBattery) var showPercentageInsideIconOnBattery
-    @Default(.showBatteryPercentageOutsideIconWhenPowered) var showPercentageOutsideIconWhenPowered
+    @Default(.batteryPercentageDisplayLocation) var percentageDisplayLocation
     @Default(.showBatteryStateInStatusIcon) var showState
 
     var body: some View {
@@ -52,9 +50,7 @@ struct StatusBarContentView: View {
             batteryLevel: viewModel.displayPercentage,
             chargingMode: viewModel.chargingMode,
             isLowPowerModeEnabled: viewModel.isLowPowerModeEnabled,
-            showPercentage: showPercentage,
-            showPercentageInsideIconOnBattery: showPercentageInsideIconOnBattery,
-            showPercentageOutsideIconWhenPowered: showPercentageOutsideIconWhenPowered,
+            percentageDisplayLocation: percentageDisplayLocation,
             showState: showState
         )
         .fixedSize()

--- a/Stasis/Views/BatteryIndicatorView.swift
+++ b/Stasis/Views/BatteryIndicatorView.swift
@@ -119,7 +119,7 @@ struct BatteryIndicatorView: View {
     private var insideContent: some View {
         let blend: BlendMode = usesPassthrough ? .destinationOut : .normal
         return HStack(spacing: 1) {
-            Text("\(batteryLevel)")
+            Text(verbatim: "\(batteryLevel)")
                 .font(.system(size: 8, weight: .heavy))
                 .monospacedDigit()
             chargingGlyph

--- a/Stasis/Views/BatteryIndicatorView.swift
+++ b/Stasis/Views/BatteryIndicatorView.swift
@@ -7,8 +7,6 @@ struct BatteryIndicatorView: View {
     var percentageDisplayLocation: PercentageDisplayLocation = .hidden
     var showState: Bool = false
 
-    private var isPowered: Bool { chargingMode != .discharging }
-
     private var shouldShowInsidePercentage: Bool {
         percentageDisplayLocation == .insideIcon
     }
@@ -17,100 +15,58 @@ struct BatteryIndicatorView: View {
         percentageDisplayLocation == .nextToIcon
     }
 
+    private var isCritical: Bool {
+        showState && batteryLevel <= 10
+    }
+
     private var fillColor: Color {
-        // Critical level takes priority over Low Power Mode.
-        if showState && batteryLevel <= 10 {
-            return .red
-        }
-        if isLowPowerModeEnabled {
-            return .yellow
-        }
+        if isCritical { return .red }
+        if isLowPowerModeEnabled { return .yellow }
+        if chargingMode == .charging { return .green }
         return .primary
     }
 
-    private var insidePercentageColor: Color {
-        // Keep strong contrast against fill colors used in the battery body.
-        if showState && batteryLevel <= 10 {
-            return .white
-        }
-        return .black
+    private var foregroundColor: Color {
+        if isCritical { return .white }
+        if isLowPowerModeEnabled { return .black }
+        if chargingMode == .charging { return .white }
+        return .white  // ignored when usesPassthrough
+    }
+
+    private var usesPassthrough: Bool {
+        !isCritical && !isLowPowerModeEnabled && chargingMode != .charging
+    }
+
+    private var trackColor: Color {
+        if isCritical { return .red }
+        if isLowPowerModeEnabled { return .yellow }
+        if chargingMode == .charging { return .green }
+        return .primary
     }
 
     private enum Layout {
         static let batteryHeight: CGFloat = 12
         static let batteryWidth: CGFloat = 24
+        static let insideBatteryWidth: CGFloat = 28
         static let terminalWidth: CGFloat = 2
         static let terminalHeight: CGFloat = 5
         static let cornerRadius: CGFloat = 3
         static let strokeWidth: CGFloat = 1
         static let fillInset: CGFloat = 1.5
-    }
-
-    private var menuBarPercentageFont: Font {
-        Font.system(size: 11)
+        static let trackOpacity: CGFloat = 0.18
+        static let outlineOpacity: CGFloat = 0.4
     }
 
     var body: some View {
         HStack(spacing: 4) {
             if shouldShowOutsidePercentage {
                 Text("\(batteryLevel)%")
-                    .font(menuBarPercentageFont)
-                    .fontWeight(.regular)
+                    .font(.system(size: 11))
                     .monospacedDigit()
             }
 
             HStack(spacing: 0) {
-                ZStack {
-                    RoundedRectangle(cornerRadius: Layout.cornerRadius)
-                        .stroke(lineWidth: Layout.strokeWidth)
-                        .opacity(0.4)
-
-                    GeometryReader { geo in
-                        let fillWidth =
-                            (geo.size.width - Layout.fillInset * 2)
-                            * CGFloat(batteryLevel)
-                            / 100
-                        RoundedRectangle(
-                            cornerRadius: Layout.cornerRadius - Layout.fillInset
-                        )
-                        .fill(fillColor)
-                        .frame(width: max(0, fillWidth))
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .padding(Layout.fillInset)
-                    }
-                }
-                .frame(width: Layout.batteryWidth, height: Layout.batteryHeight)
-                .overlay {
-                    Group {
-                        if shouldShowInsidePercentage {
-                            Text("\(batteryLevel)")
-                                .font(.system(size: batteryLevel == 100 ? 7 : 8, weight: .black))
-                                .monospacedDigit()
-                                .lineLimit(1)
-                                .minimumScaleFactor(0.8)
-                                .foregroundStyle(insidePercentageColor)
-                                .shadow(color: .black, radius: 0.5)
-                                .shadow(color: .black, radius: 0.5)
-                                .shadow(color: .black, radius: 0.5)
-                        } else if chargingMode == .charging {
-                            Image(systemName: "bolt.fill")
-                                .font(.system(size: 10, weight: .black))
-                                .foregroundStyle(.white)
-                                .shadow(color: .black, radius: 0.5)
-                                .shadow(color: .black, radius: 0.5)
-                                .shadow(color: .black, radius: 0.5)
-                        } else if chargingMode == .pluggedIn {
-                            Image(systemName: "powerplug.fill")
-                                .font(.system(size: 10, weight: .black))
-                                .rotationEffect(.degrees(-90))
-                                .foregroundStyle(.white)
-                                .shadow(color: .black, radius: 0.5)
-                                .shadow(color: .black, radius: 0.5)
-                                .shadow(color: .black, radius: 0.5)
-                        }
-                    }
-                }
-
+                batteryBody
                 BatteryTerminal(
                     width: Layout.terminalWidth,
                     height: Layout.terminalHeight,
@@ -119,6 +75,105 @@ struct BatteryIndicatorView: View {
             }
         }
         .foregroundStyle(.primary)
+    }
+
+    @ViewBuilder
+    private var batteryBody: some View {
+        if shouldShowInsidePercentage {
+            knockoutBatteryBody
+                .frame(width: Layout.insideBatteryWidth, height: Layout.batteryHeight)
+        } else {
+            overlayBatteryBody
+                .frame(width: Layout.batteryWidth, height: Layout.batteryHeight)
+        }
+    }
+
+    private var knockoutBatteryBody: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: Layout.cornerRadius)
+                .fill(trackColor.opacity(Layout.trackOpacity))
+
+            GeometryReader { geo in
+                let fillWidth =
+                    (geo.size.width - Layout.fillInset * 2)
+                    * CGFloat(batteryLevel)
+                    / 100
+                RoundedRectangle(
+                    cornerRadius: Layout.cornerRadius - Layout.fillInset
+                )
+                .fill(fillColor)
+                .frame(width: max(0, fillWidth))
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(Layout.fillInset)
+            }
+
+            insideContent
+
+            RoundedRectangle(cornerRadius: Layout.cornerRadius)
+                .stroke(lineWidth: Layout.strokeWidth)
+                .opacity(Layout.outlineOpacity)
+        }
+        .compositingGroup()
+    }
+
+    private var insideContent: some View {
+        let blend: BlendMode = usesPassthrough ? .destinationOut : .normal
+        return HStack(spacing: 1) {
+            Text("\(batteryLevel)")
+                .font(.system(size: 8, weight: .heavy))
+                .monospacedDigit()
+            chargingGlyph
+                .font(.system(size: 6, weight: .black))
+        }
+        .lineLimit(1)
+        .foregroundStyle(foregroundColor)
+        .blendMode(blend)
+    }
+
+    @ViewBuilder
+    private var chargingGlyph: some View {
+        if chargingMode == .charging {
+            Image(systemName: "bolt.fill")
+        } else if chargingMode == .pluggedIn {
+            Image(systemName: "powerplug.fill")
+                .rotationEffect(.degrees(-90))
+        }
+    }
+
+    private var overlayBatteryBody: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: Layout.cornerRadius)
+                .stroke(lineWidth: Layout.strokeWidth)
+                .opacity(Layout.outlineOpacity)
+
+            GeometryReader { geo in
+                let fillWidth =
+                    (geo.size.width - Layout.fillInset * 2)
+                    * CGFloat(batteryLevel)
+                    / 100
+                RoundedRectangle(
+                    cornerRadius: Layout.cornerRadius - Layout.fillInset
+                )
+                .fill(fillColor)
+                .frame(width: max(0, fillWidth))
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(Layout.fillInset)
+            }
+        }
+        .overlay {
+            if chargingMode == .charging {
+                Image(systemName: "bolt.fill")
+                    .font(.system(size: 10, weight: .black))
+                    .foregroundStyle(.white)
+                    .shadow(color: .black.opacity(0.6), radius: 0.5)
+            } else if chargingMode == .pluggedIn {
+                Image(systemName: "powerplug.fill")
+                    .font(.system(size: 10, weight: .black))
+                    .rotationEffect(.degrees(-90))
+                    .foregroundStyle(.white)
+                    .shadow(color: .black.opacity(0.6), radius: 0.5)
+            }
+        }
     }
 }
 
@@ -143,43 +198,46 @@ struct BatteryTerminal: View {
 
 #Preview {
     VStack(alignment: .leading, spacing: 16) {
-        // Simulate menu bar appearance
         ForEach([100, 80, 50, 20, 10, 5], id: \.self) { level in
             HStack(spacing: 20) {
-                BatteryIndicatorView(
-                    batteryLevel: level,
-                    chargingMode: .discharging
-                )
-                BatteryIndicatorView(
-                    batteryLevel: level,
-                    chargingMode: .charging
-                )
-                BatteryIndicatorView(
-                    batteryLevel: level,
-                    chargingMode: .pluggedIn
-                )
+                BatteryIndicatorView(batteryLevel: level, chargingMode: .discharging)
+                BatteryIndicatorView(batteryLevel: level, chargingMode: .charging)
+                BatteryIndicatorView(batteryLevel: level, chargingMode: .pluggedIn)
             }
         }
 
         Divider()
+        Text("Inside Icon — normal / charging / plugged")
+            .font(.caption).foregroundStyle(.secondary)
 
-        Text("Low Power Mode (yellow; critical red takes priority)")
-            .font(.caption)
-            .foregroundStyle(.secondary)
+        ForEach([100, 80, 50, 20, 10, 5], id: \.self) { level in
+            HStack(spacing: 20) {
+                BatteryIndicatorView(
+                    batteryLevel: level, chargingMode: .discharging,
+                    percentageDisplayLocation: .insideIcon, showState: true)
+                BatteryIndicatorView(
+                    batteryLevel: level, chargingMode: .charging,
+                    percentageDisplayLocation: .insideIcon, showState: true)
+                BatteryIndicatorView(
+                    batteryLevel: level, chargingMode: .pluggedIn,
+                    percentageDisplayLocation: .insideIcon, showState: true)
+            }
+        }
+
+        Divider()
+        Text("Inside Icon — Low Power Mode (critical red takes priority)")
+            .font(.caption).foregroundStyle(.secondary)
 
         ForEach([100, 50, 10, 5], id: \.self) { level in
             HStack(spacing: 20) {
                 BatteryIndicatorView(
-                    batteryLevel: level,
-                    chargingMode: .discharging,
+                    batteryLevel: level, chargingMode: .discharging,
                     isLowPowerModeEnabled: true,
-                    showState: true
-                )
+                    percentageDisplayLocation: .insideIcon, showState: true)
                 BatteryIndicatorView(
-                    batteryLevel: level,
-                    chargingMode: .charging,
-                    isLowPowerModeEnabled: true
-                )
+                    batteryLevel: level, chargingMode: .charging,
+                    isLowPowerModeEnabled: true,
+                    percentageDisplayLocation: .insideIcon, showState: true)
             }
         }
     }

--- a/Stasis/Views/BatteryIndicatorView.swift
+++ b/Stasis/Views/BatteryIndicatorView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 struct BatteryIndicatorView: View {
@@ -5,7 +6,26 @@ struct BatteryIndicatorView: View {
     let chargingMode: ChargingMode
     var isLowPowerModeEnabled: Bool = false
     var showPercentage: Bool = false
+    var showPercentageInsideIconOnBattery: Bool = false
+    var showPercentageOutsideIconWhenPowered: Bool = true
     var showState: Bool = false
+
+    private var isPowered: Bool { chargingMode != .discharging }
+
+    private var shouldShowInsidePercentage: Bool {
+        showPercentage
+            && showPercentageInsideIconOnBattery
+            && chargingMode == .discharging
+    }
+
+    private var shouldShowOutsidePercentage: Bool {
+        guard showPercentage else { return false }
+        guard showPercentageInsideIconOnBattery else { return true }
+        if isPowered {
+            return showPercentageOutsideIconWhenPowered
+        }
+        return false
+    }
 
     private var fillColor: Color {
         // Critical level takes priority over Low Power Mode.
@@ -18,6 +38,18 @@ struct BatteryIndicatorView: View {
         return .primary
     }
 
+    private var insidePercentageColor: Color {
+        // Keep strong contrast against fill colors used in the battery body.
+        if showState && batteryLevel <= 10 {
+            return .white
+        }
+        return .black
+    }
+
+    private var insidePercentageOutlineColor: Color {
+        insidePercentageColor == .white ? .black : .white
+    }
+
     private enum Layout {
         static let batteryHeight: CGFloat = 12
         static let batteryWidth: CGFloat = 24
@@ -28,12 +60,16 @@ struct BatteryIndicatorView: View {
         static let fillInset: CGFloat = 1.5
     }
 
+    private var menuBarPercentageFont: Font {
+        Font(NSFont.menuBarFont(ofSize: 11))
+    }
+
     var body: some View {
         HStack(spacing: 4) {
-            if showPercentage {
+            if shouldShowOutsidePercentage {
                 Text("\(batteryLevel)%")
-                    .font(.system(size: 10, weight: .medium))
-                    .monospacedDigit()
+                    .font(menuBarPercentageFont)
+                    .fontWeight(.regular)
             }
 
             HStack(spacing: 0) {
@@ -59,19 +95,61 @@ struct BatteryIndicatorView: View {
                 .frame(width: Layout.batteryWidth, height: Layout.batteryHeight)
                 .overlay {
                     Group {
-                        if chargingMode == .charging {
+                        if shouldShowInsidePercentage {
+                            ZStack {
+                                Text("\(batteryLevel)")
+                                    .font(.system(size: batteryLevel == 100 ? 7 : 8, weight: .black))
+                                    .monospacedDigit()
+                                    .lineLimit(1)
+                                    .minimumScaleFactor(0.8)
+                                    .foregroundStyle(insidePercentageOutlineColor)
+                                    .offset(x: -0.5, y: 0)
+                                Text("\(batteryLevel)")
+                                    .font(.system(size: batteryLevel == 100 ? 7 : 8, weight: .black))
+                                    .monospacedDigit()
+                                    .lineLimit(1)
+                                    .minimumScaleFactor(0.8)
+                                    .foregroundStyle(insidePercentageOutlineColor)
+                                    .offset(x: 0.5, y: 0)
+                                Text("\(batteryLevel)")
+                                    .font(.system(size: batteryLevel == 100 ? 7 : 8, weight: .black))
+                                    .monospacedDigit()
+                                    .lineLimit(1)
+                                    .minimumScaleFactor(0.8)
+                                    .foregroundStyle(insidePercentageOutlineColor)
+                                    .offset(x: 0, y: -0.5)
+                                Text("\(batteryLevel)")
+                                    .font(.system(size: batteryLevel == 100 ? 7 : 8, weight: .black))
+                                    .monospacedDigit()
+                                    .lineLimit(1)
+                                    .minimumScaleFactor(0.8)
+                                    .foregroundStyle(insidePercentageOutlineColor)
+                                    .offset(x: 0, y: 0.5)
+                                Text("\(batteryLevel)")
+                                    .font(.system(size: batteryLevel == 100 ? 7 : 8, weight: .black))
+                                    .monospacedDigit()
+                                    .lineLimit(1)
+                                    .minimumScaleFactor(0.8)
+                                    .foregroundStyle(insidePercentageColor)
+                            }
+                            .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        } else if chargingMode == .charging {
                             Image(systemName: "bolt.fill")
                                 .font(.system(size: 10, weight: .black))
+                                .foregroundStyle(.white)
+                                .shadow(color: .black, radius: 0.5)
+                                .shadow(color: .black, radius: 0.5)
+                                .shadow(color: .black, radius: 0.5)
                         } else if chargingMode == .pluggedIn {
                             Image(systemName: "powerplug.fill")
                                 .font(.system(size: 10, weight: .black))
                                 .rotationEffect(.degrees(-90))
+                                .foregroundStyle(.white)
+                                .shadow(color: .black, radius: 0.5)
+                                .shadow(color: .black, radius: 0.5)
+                                .shadow(color: .black, radius: 0.5)
                         }
                     }
-                    .foregroundStyle(.white)
-                    .shadow(color: .black, radius: 0.5)
-                    .shadow(color: .black, radius: 0.5)
-                    .shadow(color: .black, radius: 0.5)
                 }
 
                 BatteryTerminal(

--- a/Stasis/Views/BatteryIndicatorView.swift
+++ b/Stasis/Views/BatteryIndicatorView.swift
@@ -1,30 +1,20 @@
-import AppKit
 import SwiftUI
 
 struct BatteryIndicatorView: View {
     let batteryLevel: Int
     let chargingMode: ChargingMode
     var isLowPowerModeEnabled: Bool = false
-    var showPercentage: Bool = false
-    var showPercentageInsideIconOnBattery: Bool = false
-    var showPercentageOutsideIconWhenPowered: Bool = true
+    var percentageDisplayLocation: PercentageDisplayLocation = .hidden
     var showState: Bool = false
 
     private var isPowered: Bool { chargingMode != .discharging }
 
     private var shouldShowInsidePercentage: Bool {
-        showPercentage
-            && showPercentageInsideIconOnBattery
-            && chargingMode == .discharging
+        percentageDisplayLocation == .insideIcon
     }
 
     private var shouldShowOutsidePercentage: Bool {
-        guard showPercentage else { return false }
-        guard showPercentageInsideIconOnBattery else { return true }
-        if isPowered {
-            return showPercentageOutsideIconWhenPowered
-        }
-        return false
+        percentageDisplayLocation == .nextToIcon
     }
 
     private var fillColor: Color {
@@ -46,10 +36,6 @@ struct BatteryIndicatorView: View {
         return .black
     }
 
-    private var insidePercentageOutlineColor: Color {
-        insidePercentageColor == .white ? .black : .white
-    }
-
     private enum Layout {
         static let batteryHeight: CGFloat = 12
         static let batteryWidth: CGFloat = 24
@@ -61,7 +47,7 @@ struct BatteryIndicatorView: View {
     }
 
     private var menuBarPercentageFont: Font {
-        Font(NSFont.menuBarFont(ofSize: 11))
+        Font.system(size: 11)
     }
 
     var body: some View {
@@ -70,6 +56,7 @@ struct BatteryIndicatorView: View {
                 Text("\(batteryLevel)%")
                     .font(menuBarPercentageFont)
                     .fontWeight(.regular)
+                    .monospacedDigit()
             }
 
             HStack(spacing: 0) {
@@ -96,43 +83,15 @@ struct BatteryIndicatorView: View {
                 .overlay {
                     Group {
                         if shouldShowInsidePercentage {
-                            ZStack {
-                                Text("\(batteryLevel)")
-                                    .font(.system(size: batteryLevel == 100 ? 7 : 8, weight: .black))
-                                    .monospacedDigit()
-                                    .lineLimit(1)
-                                    .minimumScaleFactor(0.8)
-                                    .foregroundStyle(insidePercentageOutlineColor)
-                                    .offset(x: -0.5, y: 0)
-                                Text("\(batteryLevel)")
-                                    .font(.system(size: batteryLevel == 100 ? 7 : 8, weight: .black))
-                                    .monospacedDigit()
-                                    .lineLimit(1)
-                                    .minimumScaleFactor(0.8)
-                                    .foregroundStyle(insidePercentageOutlineColor)
-                                    .offset(x: 0.5, y: 0)
-                                Text("\(batteryLevel)")
-                                    .font(.system(size: batteryLevel == 100 ? 7 : 8, weight: .black))
-                                    .monospacedDigit()
-                                    .lineLimit(1)
-                                    .minimumScaleFactor(0.8)
-                                    .foregroundStyle(insidePercentageOutlineColor)
-                                    .offset(x: 0, y: -0.5)
-                                Text("\(batteryLevel)")
-                                    .font(.system(size: batteryLevel == 100 ? 7 : 8, weight: .black))
-                                    .monospacedDigit()
-                                    .lineLimit(1)
-                                    .minimumScaleFactor(0.8)
-                                    .foregroundStyle(insidePercentageOutlineColor)
-                                    .offset(x: 0, y: 0.5)
-                                Text("\(batteryLevel)")
-                                    .font(.system(size: batteryLevel == 100 ? 7 : 8, weight: .black))
-                                    .monospacedDigit()
-                                    .lineLimit(1)
-                                    .minimumScaleFactor(0.8)
-                                    .foregroundStyle(insidePercentageColor)
-                            }
-                            .frame(maxWidth: .infinity, maxHeight: .infinity)
+                            Text("\(batteryLevel)")
+                                .font(.system(size: batteryLevel == 100 ? 7 : 8, weight: .black))
+                                .monospacedDigit()
+                                .lineLimit(1)
+                                .minimumScaleFactor(0.8)
+                                .foregroundStyle(insidePercentageColor)
+                                .shadow(color: .black, radius: 0.5)
+                                .shadow(color: .black, radius: 0.5)
+                                .shadow(color: .black, radius: 0.5)
                         } else if chargingMode == .charging {
                             Image(systemName: "bolt.fill")
                                 .font(.system(size: 10, weight: .black))

--- a/Stasis/Views/Settings/GeneralSettingsView.swift
+++ b/Stasis/Views/Settings/GeneralSettingsView.swift
@@ -4,6 +4,8 @@ import SwiftUI
 struct GeneralSettingsView: View {
     @Default(.launchAtLogin) var launchAtLogin
     @Default(.showBatteryPercentageInStatusIcon) var showBatteryPercentageInStatusIcon
+    @Default(.showBatteryPercentageInsideIconOnBattery) var showBatteryPercentageInsideIconOnBattery
+    @Default(.showBatteryPercentageOutsideIconWhenPowered) var showBatteryPercentageOutsideIconWhenPowered
     @Default(.showBatteryStateInStatusIcon) var showBatteryStateInStatusIcon
     @Default(.disableNotifications) var disableNotifications
     @Default(.showChargingStatusChangedNotification) var showChargingStatusChangedNotification
@@ -16,12 +18,25 @@ struct GeneralSettingsView: View {
 
             Section {
                 Toggle("Show battery percentage", isOn: $showBatteryPercentageInStatusIcon)
+                Toggle(
+                    "Show percentage inside icon on battery",
+                    isOn: $showBatteryPercentageInsideIconOnBattery
+                )
+                .disabled(!showBatteryPercentageInStatusIcon)
+                Toggle(
+                    "Show outside percentage when on power",
+                    isOn: $showBatteryPercentageOutsideIconWhenPowered
+                )
+                .disabled(
+                    !showBatteryPercentageInStatusIcon
+                        || !showBatteryPercentageInsideIconOnBattery
+                )
                 Toggle("Show battery state", isOn: $showBatteryStateInStatusIcon)
             } header: {
                 VStack(alignment: .leading, spacing: 2) {
                     Text("Menu Bar Icon")
                     Text(
-                        "Display the current battery percentage next to the status icon in the menu bar."
+                        "Display battery percentage next to or inside the menu bar icon."
                     )
                     .font(.subheadline)
                     .foregroundStyle(.secondary)

--- a/Stasis/Views/Settings/GeneralSettingsView.swift
+++ b/Stasis/Views/Settings/GeneralSettingsView.swift
@@ -15,7 +15,7 @@ struct GeneralSettingsView: View {
             }
 
             Section {
-                Picker("Percentage display location", selection: $batteryPercentageDisplayLocation) {
+                Picker("Show percentage", selection: $batteryPercentageDisplayLocation) {
                     Text("Hidden").tag(PercentageDisplayLocation.hidden)
                     Text("Next to icon").tag(PercentageDisplayLocation.nextToIcon)
                     Text("Inside icon").tag(PercentageDisplayLocation.insideIcon)

--- a/Stasis/Views/Settings/GeneralSettingsView.swift
+++ b/Stasis/Views/Settings/GeneralSettingsView.swift
@@ -3,9 +3,7 @@ import SwiftUI
 
 struct GeneralSettingsView: View {
     @Default(.launchAtLogin) var launchAtLogin
-    @Default(.showBatteryPercentageInStatusIcon) var showBatteryPercentageInStatusIcon
-    @Default(.showBatteryPercentageInsideIconOnBattery) var showBatteryPercentageInsideIconOnBattery
-    @Default(.showBatteryPercentageOutsideIconWhenPowered) var showBatteryPercentageOutsideIconWhenPowered
+    @Default(.batteryPercentageDisplayLocation) var batteryPercentageDisplayLocation
     @Default(.showBatteryStateInStatusIcon) var showBatteryStateInStatusIcon
     @Default(.disableNotifications) var disableNotifications
     @Default(.showChargingStatusChangedNotification) var showChargingStatusChangedNotification
@@ -17,20 +15,11 @@ struct GeneralSettingsView: View {
             }
 
             Section {
-                Toggle("Show battery percentage", isOn: $showBatteryPercentageInStatusIcon)
-                Toggle(
-                    "Show percentage inside icon on battery",
-                    isOn: $showBatteryPercentageInsideIconOnBattery
-                )
-                .disabled(!showBatteryPercentageInStatusIcon)
-                Toggle(
-                    "Show outside percentage when on power",
-                    isOn: $showBatteryPercentageOutsideIconWhenPowered
-                )
-                .disabled(
-                    !showBatteryPercentageInStatusIcon
-                        || !showBatteryPercentageInsideIconOnBattery
-                )
+                Picker("Percentage display location", selection: $batteryPercentageDisplayLocation) {
+                    ForEach(PercentageDisplayLocation.allCases) { location in
+                        Text(LocalizedStringKey(location.rawValue)).tag(location)
+                    }
+                }
                 Toggle("Show battery state", isOn: $showBatteryStateInStatusIcon)
             } header: {
                 VStack(alignment: .leading, spacing: 2) {

--- a/Stasis/Views/Settings/GeneralSettingsView.swift
+++ b/Stasis/Views/Settings/GeneralSettingsView.swift
@@ -16,9 +16,9 @@ struct GeneralSettingsView: View {
 
             Section {
                 Picker("Percentage display location", selection: $batteryPercentageDisplayLocation) {
-                    ForEach(PercentageDisplayLocation.allCases) { location in
-                        Text(LocalizedStringKey(location.rawValue)).tag(location)
-                    }
+                    Text("Hidden").tag(PercentageDisplayLocation.hidden)
+                    Text("Next to icon").tag(PercentageDisplayLocation.nextToIcon)
+                    Text("Inside icon").tag(PercentageDisplayLocation.insideIcon)
                 }
                 Toggle("Show battery state", isOn: $showBatteryStateInStatusIcon)
             } header: {


### PR DESCRIPTION
This pull request introduces new customization options for how the battery percentage is displayed in the menu bar icon, allowing users to choose whether the percentage appears inside the icon when on battery, and/or outside the icon when powered. It updates the settings UI, underlying logic, and localization strings to support these options.

**Battery Percentage Display Customization:**

* Added two new user defaults: `showBatteryPercentageInsideIconOnBattery` and `showBatteryPercentageOutsideIconWhenPowered`, enabling users to control whether the battery percentage appears inside the icon while on battery and outside the icon when plugged in, respectively.
* Updated `StatusBarContentView` and `BatteryIndicatorView` to respect these new settings, including logic to determine when to show the percentage inside or outside the icon based on charging state and user preferences. [[1]](diffhunk://#diff-03cd01301bc7d81cc2020c0a66598b7db6df20c7a98ead4f4f8d7daec138d4bcR46-R56) [[2]](diffhunk://#diff-34fd12a3af5471c99ad4d92bf84d55365406e71ec09396b8e84a4fc79690108eR1-R47) [[3]](diffhunk://#diff-34fd12a3af5471c99ad4d92bf84d55365406e71ec09396b8e84a4fc79690108eR58-R67) [[4]](diffhunk://#diff-34fd12a3af5471c99ad4d92bf84d55365406e71ec09396b8e84a4fc79690108eL57-R148)

**Settings UI Enhancements:**

* Modified `GeneralSettingsView` to include toggles for the new settings, with appropriate enabling/disabling logic based on related settings. Updated the settings section description to reflect the new options. [[1]](diffhunk://#diff-81b929e0819ef9bb3f14ddeba68f950d165d564f5242371e2365ed575be1c912R7-R8) [[2]](diffhunk://#diff-81b929e0819ef9bb3f14ddeba68f950d165d564f5242371e2365ed575be1c912R21-R39)

<img width="475" height="191" alt="Screenshot 2026-05-13 at 2 59 12 PM" src="https://github.com/user-attachments/assets/5cd132c0-c61d-4891-a6fb-49e2812230ba" />

**Localization Updates:**

* Added new localization string keys for the new settings and updated descriptions to match the new functionality. [[1]](diffhunk://#diff-3478e5497afc2cec0f89eb06350fcd18a2dde63350cdb67ba1689e78fe96d584R4-R6) [[2]](diffhunk://#diff-3478e5497afc2cec0f89eb06350fcd18a2dde63350cdb67ba1689e78fe96d584R817-R822) [[3]](diffhunk://#diff-3478e5497afc2cec0f89eb06350fcd18a2dde63350cdb67ba1689e78fe96d584R1620-R1625)

> Closes #6 