### PR TITLE
Refactor time remaining calculation and integrate estimator

### DIFF
--- a/Stasis/Models/TimeRemainingEstimator.swift
+++ b/Stasis/Models/TimeRemainingEstimator.swift
@@ -1,0 +1,104 @@
+import Foundation
+
+@MainActor
+class TimeRemainingEstimator {
+    private var trendSample: (date: Date, percentage: Int, isCharging: Bool)?
+
+    func formatTimeRemaining(
+        reportedMinutes: Int,
+        powerSource: PowerSource,
+        isCharging: Bool,
+        adapterConnected: Bool,
+        batteryPercentage: Int,
+        chargingTargetPercentage: Int
+    ) -> String {
+        if adapterConnected && !isCharging {
+            return "N/A"
+        }
+
+        let adjustedReportedMinutes = adjustedReportedMinutesToTarget(
+            reportedMinutes: reportedMinutes,
+            isCharging: isCharging,
+            batteryPercentage: batteryPercentage,
+            targetPercentage: chargingTargetPercentage
+        )
+
+        let fallbackMinutes = estimateMinutesFromTrend(
+            batteryPercentage: batteryPercentage,
+            isCharging: isCharging,
+            adapterConnected: adapterConnected,
+            targetPercentage: chargingTargetPercentage
+        )
+
+        let effectiveMinutes = adjustedReportedMinutes >= 0 ? adjustedReportedMinutes : fallbackMinutes
+        guard let effectiveMinutes, effectiveMinutes >= 0 else {
+            return "Calculating..."
+        }
+
+        let hours = effectiveMinutes / 60
+        let mins = effectiveMinutes % 60
+        return String(format: "%02d:%02d", hours, mins)
+    }
+
+    private func adjustedReportedMinutesToTarget(
+        reportedMinutes: Int,
+        isCharging: Bool,
+        batteryPercentage: Int,
+        targetPercentage: Int
+    ) -> Int {
+        guard reportedMinutes >= 0 else { return -1 }
+        guard isCharging else { return reportedMinutes }
+
+        if batteryPercentage >= targetPercentage {
+            return 0
+        }
+
+        if targetPercentage >= 100 || batteryPercentage >= 100 {
+            return reportedMinutes
+        }
+
+        let remainingToTarget = max(0, targetPercentage - batteryPercentage)
+        let remainingToFull = max(1, 100 - batteryPercentage)
+        let scaled = Double(reportedMinutes) * Double(remainingToTarget) / Double(remainingToFull)
+        return Int(ceil(scaled))
+    }
+
+    private func estimateMinutesFromTrend(
+        batteryPercentage: Int,
+        isCharging: Bool,
+        adapterConnected: Bool,
+        targetPercentage: Int
+    ) -> Int? {
+        let now = Date()
+        defer {
+            trendSample = (date: now, percentage: batteryPercentage, isCharging: isCharging)
+        }
+
+        guard !(adapterConnected && !isCharging) else { return nil }
+        guard let previous = trendSample else { return nil }
+        guard previous.isCharging == isCharging else { return nil }
+
+        let elapsedMinutes = now.timeIntervalSince(previous.date) / 60
+        guard elapsedMinutes >= 0.5 else { return nil }
+
+        let deltaPercent = batteryPercentage - previous.percentage
+        guard deltaPercent != 0 else { return nil }
+
+        let percentPerMinute = abs(Double(deltaPercent) / elapsedMinutes)
+        guard percentPerMinute > 0 else { return nil }
+
+        let remainingPercent: Int = {
+            if isCharging {
+                return max(0, targetPercentage - batteryPercentage)
+            }
+            return max(0, batteryPercentage)
+        }()
+
+        if remainingPercent == 0 {
+            return 0
+        }
+
+        let minutes = Double(remainingPercent) / percentPerMinute
+        return Int(ceil(minutes))
+    }
+}

--- a/Stasis/Models/TimeRemainingEstimator.swift
+++ b/Stasis/Models/TimeRemainingEstimator.swift
@@ -1,69 +1,38 @@
 import Foundation
 
-@MainActor
-class TimeRemainingEstimator {
-    private var trendSample: (date: Date, percentage: Int, isCharging: Bool)?
+struct TimeRemainingEstimator {
+    private struct TrendSample {
+        let date: Date
+        let percentage: Int
+        let isCharging: Bool
+    }
 
-    func formatTimeRemaining(
+    private var trendSample: TrendSample?
+
+    mutating func estimateTimeRemaining(
         reportedMinutes: Int,
-        powerSource: PowerSource,
         isCharging: Bool,
         adapterConnected: Bool,
         batteryPercentage: Int,
         chargingTargetPercentage: Int
-    ) -> String {
-        if adapterConnected && !isCharging {
-            return "N/A"
+    ) -> Int? {
+        if batteryPercentage >= chargingTargetPercentage && isCharging {
+            return 0
         }
 
-        let adjustedReportedMinutes = adjustedReportedMinutesToTarget(
-            reportedMinutes: reportedMinutes,
-            isCharging: isCharging,
-            batteryPercentage: batteryPercentage,
-            targetPercentage: chargingTargetPercentage
-        )
+        if reportedMinutes >= 0 {
+            return reportedMinutes
+        }
 
-        let fallbackMinutes = estimateMinutesFromTrend(
+        return estimateMinutesFromTrend(
             batteryPercentage: batteryPercentage,
             isCharging: isCharging,
             adapterConnected: adapterConnected,
             targetPercentage: chargingTargetPercentage
         )
-
-        let effectiveMinutes = adjustedReportedMinutes >= 0 ? adjustedReportedMinutes : fallbackMinutes
-        guard let effectiveMinutes, effectiveMinutes >= 0 else {
-            return "Calculating..."
-        }
-
-        let hours = effectiveMinutes / 60
-        let mins = effectiveMinutes % 60
-        return String(format: "%02d:%02d", hours, mins)
     }
 
-    private func adjustedReportedMinutesToTarget(
-        reportedMinutes: Int,
-        isCharging: Bool,
-        batteryPercentage: Int,
-        targetPercentage: Int
-    ) -> Int {
-        guard reportedMinutes >= 0 else { return -1 }
-        guard isCharging else { return reportedMinutes }
-
-        if batteryPercentage >= targetPercentage {
-            return 0
-        }
-
-        if targetPercentage >= 100 || batteryPercentage >= 100 {
-            return reportedMinutes
-        }
-
-        let remainingToTarget = max(0, targetPercentage - batteryPercentage)
-        let remainingToFull = max(1, 100 - batteryPercentage)
-        let scaled = Double(reportedMinutes) * Double(remainingToTarget) / Double(remainingToFull)
-        return Int(ceil(scaled))
-    }
-
-    private func estimateMinutesFromTrend(
+    private mutating func estimateMinutesFromTrend(
         batteryPercentage: Int,
         isCharging: Bool,
         adapterConnected: Bool,
@@ -71,7 +40,7 @@ class TimeRemainingEstimator {
     ) -> Int? {
         let now = Date()
         defer {
-            trendSample = (date: now, percentage: batteryPercentage, isCharging: isCharging)
+            trendSample = TrendSample(date: now, percentage: batteryPercentage, isCharging: isCharging)
         }
 
         guard !(adapterConnected && !isCharging) else { return nil }

--- a/Stasis/Models/TimeRemainingEstimator.swift
+++ b/Stasis/Models/TimeRemainingEstimator.swift
@@ -1,18 +1,9 @@
 import Foundation
 
 struct TimeRemainingEstimator {
-    private struct TrendSample {
-        let date: Date
-        let percentage: Int
-        let isCharging: Bool
-    }
-
-    private var trendSample: TrendSample?
-
-    mutating func estimateTimeRemaining(
+    func estimateTimeRemaining(
         reportedMinutes: Int,
         isCharging: Bool,
-        adapterConnected: Bool,
         batteryPercentage: Int,
         chargingTargetPercentage: Int
     ) -> Int? {
@@ -20,54 +11,10 @@ struct TimeRemainingEstimator {
             return 0
         }
 
-        if reportedMinutes >= 0 {
-            return reportedMinutes
+        guard reportedMinutes >= 0 else {
+            return nil
         }
 
-        return estimateMinutesFromTrend(
-            batteryPercentage: batteryPercentage,
-            isCharging: isCharging,
-            adapterConnected: adapterConnected,
-            targetPercentage: chargingTargetPercentage
-        )
-    }
-
-    private mutating func estimateMinutesFromTrend(
-        batteryPercentage: Int,
-        isCharging: Bool,
-        adapterConnected: Bool,
-        targetPercentage: Int
-    ) -> Int? {
-        let now = Date()
-        defer {
-            trendSample = TrendSample(date: now, percentage: batteryPercentage, isCharging: isCharging)
-        }
-
-        guard !(adapterConnected && !isCharging) else { return nil }
-        guard let previous = trendSample else { return nil }
-        guard previous.isCharging == isCharging else { return nil }
-
-        let elapsedMinutes = now.timeIntervalSince(previous.date) / 60
-        guard elapsedMinutes >= 0.5 else { return nil }
-
-        let deltaPercent = batteryPercentage - previous.percentage
-        guard deltaPercent != 0 else { return nil }
-
-        let percentPerMinute = abs(Double(deltaPercent) / elapsedMinutes)
-        guard percentPerMinute > 0 else { return nil }
-
-        let remainingPercent: Int = {
-            if isCharging {
-                return max(0, targetPercentage - batteryPercentage)
-            }
-            return max(0, batteryPercentage)
-        }()
-
-        if remainingPercent == 0 {
-            return 0
-        }
-
-        let minutes = Double(remainingPercent) / percentPerMinute
-        return Int(ceil(minutes))
+        return reportedMinutes
     }
 }

--- a/Stasis/ViewModels/MenuViewModel.swift
+++ b/Stasis/ViewModels/MenuViewModel.swift
@@ -37,6 +37,7 @@ class MenuViewModel {
     private var metricsObservation: Task<Void, Never>?
     private var settingsObservation: Task<Void, Never>?
     private var uptimeTask: Task<Void, Never>?
+    private let timeEstimator = TimeRemainingEstimator()
 
     init(batteryService: BatteryService, chargeManager: ChargeManager) {
         self.batteryService = batteryService
@@ -107,8 +108,7 @@ class MenuViewModel {
             powerSourceText = "Battery & Power Adapter"
         }
 
-        let formatted = formatTimeRemaining(minutes: metrics.timeRemaining)
-        timeRemainingText = formatted.isEmpty ? "Calculating..." : formatted
+        timeRemainingText = formatTimeRemaining(minutes: metrics.timeRemaining, powerSource: derivedPowerSource, isCharging: metrics.isCharging)
 
         updateUptimeText()
 
@@ -166,10 +166,18 @@ class MenuViewModel {
             return
         }
 
-        let uptime = Date().timeIntervalSince(bootTimestamp)
-        let hours = Int(uptime) / 3600
-        let minutes = (Int(uptime) % 3600) / 60
-        uptimeText = String(format: "%02d:%02d", hours, minutes)
+        let uptime = max(0, Int(Date().timeIntervalSince(bootTimestamp)))
+        let days = uptime / 86_400
+        let hours = (uptime % 86_400) / 3_600
+        let minutes = (uptime % 3_600) / 60
+
+        if days > 0 {
+            uptimeText = "\(days)D \(hours)H \(minutes)M"
+        } else if hours > 0 {
+            uptimeText = "\(hours)H \(minutes)M"
+        } else {
+            uptimeText = "\(minutes)M"
+        }
     }
 
     private func startUptimeTimer() {
@@ -203,13 +211,22 @@ class MenuViewModel {
         NSApplication.shared.terminate(nil)
     }
 
-    private func formatTimeRemaining(minutes: Int) -> String {
-        if minutes < 0 {
-            return ""
+    private func formatTimeRemaining(minutes: Int, powerSource: PowerSource, isCharging: Bool) -> String {
+        return timeEstimator.formatTimeRemaining(
+            reportedMinutes: minutes,
+            powerSource: powerSource,
+            isCharging: isCharging,
+            adapterConnected: adapterConnected,
+            batteryPercentage: displayPercentage,
+            chargingTargetPercentage: chargingTargetPercentage
+        )
+    }
+
+    private var chargingTargetPercentage: Int {
+        if Defaults[.manageCharging] && !chargeLimitOverrideActive {
+            return Defaults[.chargeLimit]
         }
-        let hours = minutes / 60
-        let mins = minutes % 60
-        return String(format: "%02d:%02d", hours, mins)
+        return 100
     }
 
     deinit {

--- a/Stasis/ViewModels/MenuViewModel.swift
+++ b/Stasis/ViewModels/MenuViewModel.swift
@@ -37,7 +37,7 @@ class MenuViewModel {
     private var metricsObservation: Task<Void, Never>?
     private var settingsObservation: Task<Void, Never>?
     private var uptimeTask: Task<Void, Never>?
-    private let timeEstimator = TimeRemainingEstimator()
+    private var timeEstimator = TimeRemainingEstimator()
 
     init(batteryService: BatteryService, chargeManager: ChargeManager) {
         self.batteryService = batteryService
@@ -108,8 +108,6 @@ class MenuViewModel {
             powerSourceText = "Battery & Power Adapter"
         }
 
-        timeRemainingText = formatTimeRemaining(minutes: metrics.timeRemaining, powerSource: derivedPowerSource, isCharging: metrics.isCharging)
-
         updateUptimeText()
 
         if derivedPowerSource == .acAdapter {
@@ -144,6 +142,8 @@ class MenuViewModel {
         isCharging = metrics.isCharging
         adapterConnected = adapter.adapterConnected
 
+        timeRemainingText = formatTimeRemaining(minutes: metrics.timeRemaining, isCharging: metrics.isCharging)
+
         cycleCountText = "\(metrics.cycleCount)"
         batteryHealthText = "\(metrics.batteryHealth)%"
     }
@@ -167,17 +167,10 @@ class MenuViewModel {
         }
 
         let uptime = max(0, Int(Date().timeIntervalSince(bootTimestamp)))
-        let days = uptime / 86_400
-        let hours = (uptime % 86_400) / 3_600
-        let minutes = (uptime % 3_600) / 60
-
-        if days > 0 {
-            uptimeText = "\(days)D \(hours)H \(minutes)M"
-        } else if hours > 0 {
-            uptimeText = "\(hours)H \(minutes)M"
-        } else {
-            uptimeText = "\(minutes)M"
-        }
+        let duration = Duration.seconds(uptime)
+        uptimeText = duration.formatted(
+            .units(allowed: [.days, .hours, .minutes], width: .abbreviated)
+        )
     }
 
     private func startUptimeTimer() {
@@ -211,15 +204,24 @@ class MenuViewModel {
         NSApplication.shared.terminate(nil)
     }
 
-    private func formatTimeRemaining(minutes: Int, powerSource: PowerSource, isCharging: Bool) -> String {
-        return timeEstimator.formatTimeRemaining(
+    private func formatTimeRemaining(minutes: Int, isCharging: Bool) -> String {
+        if adapterConnected && !isCharging {
+            return "N/A"
+        }
+
+        let estimatedMinutes = timeEstimator.estimateTimeRemaining(
             reportedMinutes: minutes,
-            powerSource: powerSource,
             isCharging: isCharging,
             adapterConnected: adapterConnected,
             batteryPercentage: displayPercentage,
             chargingTargetPercentage: chargingTargetPercentage
         )
+        guard let validMinutes = estimatedMinutes, validMinutes >= 0 else {
+            return "Calculating..."
+        }
+        let hours = validMinutes / 60
+        let mins = validMinutes % 60
+        return String(format: "%02d:%02d", hours, mins)
     }
 
     private var chargingTargetPercentage: Int {

--- a/Stasis/ViewModels/MenuViewModel.swift
+++ b/Stasis/ViewModels/MenuViewModel.swift
@@ -29,7 +29,9 @@ class MenuViewModel {
     var powerSource: PowerSource = .battery
     var isCharging: Bool = false
 
-    var chargeLimitOverrideActive: Bool { chargeManager.chargeLimitOverrideActive }
+    var chargeLimitOverrideActive: Bool {
+        chargeManager.chargeLimitOverrideActive
+    }
     var forceDischargeActive: Bool { chargeManager.forceDischargeActive }
     var manageChargingEnabled: Bool { Defaults[.manageCharging] }
     var adapterConnected: Bool = false
@@ -37,7 +39,7 @@ class MenuViewModel {
     private var metricsObservation: Task<Void, Never>?
     private var settingsObservation: Task<Void, Never>?
     private var uptimeTask: Task<Void, Never>?
-    private var timeEstimator = TimeRemainingEstimator()
+    private let timeEstimator = TimeRemainingEstimator()
 
     init(batteryService: BatteryService, chargeManager: ChargeManager) {
         self.batteryService = batteryService
@@ -71,7 +73,10 @@ class MenuViewModel {
 
     private func startObservingSettings() {
         settingsObservation = Task { [weak self] in
-            for await _ in Defaults.updates([.useHardwarePercentage], initial: false) {
+            for await _ in Defaults.updates(
+                [.useHardwarePercentage],
+                initial: false
+            ) {
                 guard let self else { return }
                 self.updateFormattedValues(
                     from: self.batteryService.metrics,
@@ -89,7 +94,10 @@ class MenuViewModel {
         chargeManager.toggleForceDischarge()
     }
 
-    private func updateFormattedValues(from metrics: BatteryMetrics, adapter: AdapterMetrics) {
+    private func updateFormattedValues(
+        from metrics: BatteryMetrics,
+        adapter: AdapterMetrics
+    ) {
         let useHardware = Defaults[.useHardwarePercentage]
         let percentage =
             useHardware
@@ -97,7 +105,10 @@ class MenuViewModel {
         displayPercentage = percentage
         batteryPercentageText = "\(percentage)%"
 
-        let derivedPowerSource = derivePowerSource(battery: metrics, adapter: adapter)
+        let derivedPowerSource = derivePowerSource(
+            battery: metrics,
+            adapter: adapter
+        )
 
         switch derivedPowerSource {
         case .battery:
@@ -126,8 +137,12 @@ class MenuViewModel {
         batteryTemperatureText =
             "\(metrics.batteryTemperature.formatted(.number.precision(.fractionLength(1))))°C"
 
-        let voltageFormat = FloatingPointFormatStyle<Double>.number.precision(.fractionLength(2))
-        let currentFormat = FloatingPointFormatStyle<Double>.number.precision(.fractionLength(2))
+        let voltageFormat = FloatingPointFormatStyle<Double>.number.precision(
+            .fractionLength(2)
+        )
+        let currentFormat = FloatingPointFormatStyle<Double>.number.precision(
+            .fractionLength(2)
+        )
 
         externalInputText =
             "\(adapter.adapterVoltage.formatted(voltageFormat))V @ \(adapter.adapterCurrent.formatted(currentFormat))A"
@@ -142,13 +157,19 @@ class MenuViewModel {
         isCharging = metrics.isCharging
         adapterConnected = adapter.adapterConnected
 
-        timeRemainingText = formatTimeRemaining(minutes: metrics.timeRemaining, isCharging: metrics.isCharging)
+        timeRemainingText = formatTimeRemaining(
+            minutes: metrics.timeRemaining,
+            isCharging: metrics.isCharging
+        )
 
         cycleCountText = "\(metrics.cycleCount)"
         batteryHealthText = "\(metrics.batteryHealth)%"
     }
 
-    private func derivePowerSource(battery: BatteryMetrics, adapter: AdapterMetrics) -> PowerSource {
+    private func derivePowerSource(
+        battery: BatteryMetrics,
+        adapter: AdapterMetrics
+    ) -> PowerSource {
         guard adapter.adapterConnected else { return .battery }
 
         if adapter.adapterPower == 0 {
@@ -212,7 +233,6 @@ class MenuViewModel {
         let estimatedMinutes = timeEstimator.estimateTimeRemaining(
             reportedMinutes: minutes,
             isCharging: isCharging,
-            adapterConnected: adapterConnected,
             batteryPercentage: displayPercentage,
             chargingTargetPercentage: chargingTargetPercentage
         )


### PR DESCRIPTION
This pull request introduces a new `TimeRemainingEstimator` class to improve the estimation and formatting of battery time remaining, and refactors how this information is displayed in the menu. It also enhances the display of system uptime to show days, hours, and minutes for better readability.

**Battery time estimation improvements:**

* Added a new `TimeRemainingEstimator` class (`Stasis/Models/TimeRemainingEstimator.swift`) that calculates and formats time remaining, taking into account charging status, power source, charging targets, and trends in battery percentage. This provides more accurate and user-friendly time remaining estimates.
* Updated `MenuViewModel` to use the new `TimeRemainingEstimator` for displaying time remaining, passing relevant parameters such as power source, charging status, and charging target. [[1]](diffhunk://#diff-e5795c27b25b6d9815d8eb7569e2d1eb69a145a0df3e8563a4b6c19112922bffR40) [[2]](diffhunk://#diff-e5795c27b25b6d9815d8eb7569e2d1eb69a145a0df3e8563a4b6c19112922bffL110-R111) [[3]](diffhunk://#diff-e5795c27b25b6d9815d8eb7569e2d1eb69a145a0df3e8563a4b6c19112922bffL206-R229)
* Added logic to determine the current charging target percentage, considering user settings and overrides.

**User interface enhancements:**

* Improved the formatting of uptime in `MenuViewModel` to display days, hours, and minutes, making it clearer for users with long uptimes.
<img width="346" height="500" alt="Screenshot 2026-05-13 at 4 51 32 PM" src="https://github.com/user-attachments/assets/c2103ac0-b8ac-49ed-a234-d34e146e266c" />

> Closes #9 