### PR TITLE
Add outgoing power visualization to Sankey diagram

### DIFF
--- a/Helper/Helper.swift
+++ b/Helper/Helper.swift
@@ -68,4 +68,18 @@ final class Helper: NSObject, HelperProtocol {
             reply(false, false, false, false)
         }
     }
+
+    func getOutputTelemetrySMCKeyAvailability(
+        reply: @escaping @Sendable ([String]) -> Void
+    ) {
+        do {
+            let available = try SMCPowerTelemetry.availableCandidateKeys()
+            reply(available)
+        } catch {
+            logger.error(
+                "Failed to probe output telemetry SMC key availability: \(error.localizedDescription)"
+            )
+            reply([])
+        }
+    }
 }

--- a/Helper/HelperProtocol.swift
+++ b/Helper/HelperProtocol.swift
@@ -5,6 +5,8 @@ import Foundation
         reply: @escaping @Sendable (Double, Double, Double) -> Void)
     func readAdapterMetrics(
         reply: @escaping @Sendable (Double, Double, Double) -> Void)
+    func getOutputTelemetrySMCKeyAvailability(
+        reply: @escaping @Sendable ([String]) -> Void)
     func getCapabilities(
         reply: @escaping @Sendable (Bool, Bool, Bool, Bool) -> Void)
 }

--- a/SMCPower/SMCPowerTelemetry.swift
+++ b/SMCPower/SMCPowerTelemetry.swift
@@ -1,0 +1,24 @@
+import SMCKit
+
+public struct SMCPowerTelemetry: Sendable {
+    // Candidate keys based on public reverse-engineering references
+    // (e.g. Asahi macsmc-power) for adapter/system power telemetry.
+    public static let candidateKeys: [String] = [
+        "PDTR", // Input power
+        "PSTR", // System load
+        "PMVR", // Rail power sample used alongside PDTR/PSTR
+        "AC-W", // Active charging port index
+    ]
+
+    public static func availableCandidateKeys() throws -> [String] {
+        try candidateKeys.filter {
+            guard let code = fourCharCode(from: $0) else { return false }
+            return try SMCKit.shared.isKeyFound(code)
+        }
+    }
+
+    private static func fourCharCode(from key: String) -> UInt32? {
+        guard key.utf8.count == 4 else { return nil }
+        return key.utf8.reduce(0) { ($0 << 8) | UInt32($1) }
+    }
+}

--- a/Stasis/AppDelegate.swift
+++ b/Stasis/AppDelegate.swift
@@ -65,7 +65,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
                     .showPowerSource, .showTimeTillDischarge, .showBatteryCycleCount,
                     .showBatteryHealth, .showBatteryTemperature, .showUptime,
                     .showBatteryMode, .showInternalPower, .showExternalPower,
-                    .showPowerDistribution, .manageCharging,
+                    .showPowerDistribution, .showOutputPortsText,
+                    .outputVisualizationMode, .manageCharging,
                 ],
                 initial: false
             ) {

--- a/Stasis/DefaultsKeys.swift
+++ b/Stasis/DefaultsKeys.swift
@@ -4,6 +4,13 @@ import smc_power
 
 extension MagSafeLEDState: Defaults.Serializable {}
 
+enum OutputVisualizationMode: String, CaseIterable, Defaults.Serializable {
+    case off
+    case powerOnly
+    case batteryOnly
+    case always
+}
+
 extension Defaults.Keys {
     // General
     static let launchAtLogin = Key<Bool>("launchAtLogin", default: false)
@@ -30,6 +37,11 @@ extension Defaults.Keys {
     static let showInternalPower = Key<Bool>("showInternalPower", default: true)
     static let showExternalPower = Key<Bool>("showExternalPower", default: true)
     static let showPowerDistribution = Key<Bool>("showPowerDistribution", default: false)
+    static let showOutputPortsText = Key<Bool>("showOutputPortsText", default: true)
+    static let outputVisualizationMode = Key<OutputVisualizationMode>(
+        "outputVisualizationMode",
+        default: .always
+    )
 
     // Charging
     static let manageCharging = Key<Bool>("manageCharging", default: false)

--- a/Stasis/L10n/Localizable.xcstrings
+++ b/Stasis/L10n/Localizable.xcstrings
@@ -119,6 +119,9 @@
         }
       }
     },
+    "Always" : {
+
+    },
     "Approve Stasis in System Settings → Login Items to continue." : {
 
     },
@@ -264,6 +267,9 @@
           }
         }
       }
+    },
+    "Battery Only" : {
+
     },
     "Battery Power Metrics" : {
       "localizations" : {
@@ -1378,6 +1384,12 @@
         }
       }
     },
+    "Output Ports" : {
+
+    },
+    "Output ports text row" : {
+
+    },
     "Pause charging when the battery temperature exceeds the threshold." : {
       "localizations" : {
         "de" : {
@@ -1461,6 +1473,9 @@
           }
         }
       }
+    },
+    "Power Only" : {
+
     },
     "Power source" : {
       "localizations" : {
@@ -1609,6 +1624,9 @@
       }
     },
     "Show battery state" : {
+
+    },
+    "Show outgoing output" : {
 
     },
     "Sleep Prevention" : {

--- a/Stasis/Models/BatteryMetrics.swift
+++ b/Stasis/Models/BatteryMetrics.swift
@@ -16,7 +16,6 @@ struct BatteryMetrics: Codable, Equatable {
     var batteryVoltage: Double = 0
     var batteryCurrent: Double = 0
     var batteryPower: Double = 0
-    var systemInputPower: Double = 0
     var outputPower: Double = 0
     var outputPorts: [OutputPortPower] = []
     var batteryTemperature: Double = 0

--- a/Stasis/Models/BatteryMetrics.swift
+++ b/Stasis/Models/BatteryMetrics.swift
@@ -1,5 +1,12 @@
 import Foundation
 
+struct OutputPortPower: Codable, Equatable, Identifiable {
+    var portIndex: Int
+    var powerWatts: Double
+
+    var id: Int { portIndex }
+}
+
 struct BatteryMetrics: Codable, Equatable {
     var batteryPercentage: Int = 0
     var hardwareBatteryPercentage: Int = 0
@@ -9,6 +16,9 @@ struct BatteryMetrics: Codable, Equatable {
     var batteryVoltage: Double = 0
     var batteryCurrent: Double = 0
     var batteryPower: Double = 0
+    var systemInputPower: Double = 0
+    var outputPower: Double = 0
+    var outputPorts: [OutputPortPower] = []
     var batteryTemperature: Double = 0
 
     var batteryHealth: Int = 0
@@ -19,6 +29,7 @@ struct BatteryMetrics: Codable, Equatable {
 
 struct AdapterMetrics: Equatable {
     var adapterConnected: Bool = false
+    var adapterCapacityWatts: Int = 0
     var adapterVoltage: Double = 0
     var adapterCurrent: Double = 0
     var adapterPower: Double = 0

--- a/Stasis/Services/BatteryService.swift
+++ b/Stasis/Services/BatteryService.swift
@@ -48,6 +48,9 @@ class BatteryService {
         logger.info("BatteryService initialized")
         xpcManager.connect()
         startIOKitMonitoring()
+        Task { [weak self] in
+            await self?.logOutputTelemetrySMCKeyAvailability()
+        }
     }
 
     func loadCapabilities() async {
@@ -301,6 +304,36 @@ class BatteryService {
             throw XPCError.helperUnavailable
         }
         return helper
+    }
+
+    private func logOutputTelemetrySMCKeyAvailability() async {
+        let logger = self.logger
+        guard
+            let helper = xpcManager.getHelper(errorHandler: { error in
+                logger.error(
+                    "XPC error probing output telemetry SMC keys: \(error.localizedDescription)"
+                )
+            })
+        else {
+            logger.warning("Helper unavailable for output telemetry SMC key probe")
+            return
+        }
+
+        let keys = await withCheckedContinuation { continuation in
+            helper.getOutputTelemetrySMCKeyAvailability { keys in
+                continuation.resume(returning: keys)
+            }
+        }
+
+        if keys.isEmpty {
+            logger.info(
+                "Output telemetry SMC candidate keys not found (PDTR/PSTR/PMVR/AC-W)"
+            )
+        } else {
+            logger.info(
+                "Output telemetry SMC candidate keys available: \(keys.joined(separator: ", "))"
+            )
+        }
     }
 
     func stop() {

--- a/Stasis/Services/IOKitService.swift
+++ b/Stasis/Services/IOKitService.swift
@@ -11,6 +11,7 @@ class IOKitService {
     private var batteryService: io_service_t = 0
 
     private var continuation: AsyncStream<(BatteryMetrics, AdapterMetrics)>.Continuation?
+    private var refreshTask: Task<Void, Never>?
 
     private let logger = Logger(
         subsystem: "com.srimanachanta.stasis",
@@ -82,9 +83,12 @@ class IOKitService {
         }
 
         emitMetrics()
+        startRefreshLoop()
     }
 
     private func stop() {
+        refreshTask?.cancel()
+        refreshTask = nil
         if interestNotification != 0 {
             IOObjectRelease(interestNotification)
             interestNotification = 0
@@ -128,8 +132,13 @@ class IOKitService {
 
         batteryMetrics.externalConnected =
             getPropertyValue(batteryService, key: "ExternalConnected") ?? false
+        batteryMetrics.systemInputPower = getSystemInputPowerWatts()
+        batteryMetrics.outputPorts = getOutputPortPowers()
+        batteryMetrics.outputPower = batteryMetrics.outputPorts.reduce(0) { $0 + $1.powerWatts }
 
-        adapterMetrics.adapterConnected = isAdapterConnected()
+        let adapterRatedWatts = getAdapterRatedWatts()
+        adapterMetrics.adapterCapacityWatts = adapterRatedWatts ?? 0
+        adapterMetrics.adapterConnected = (adapterRatedWatts ?? 0) > 0
 
         if let temp = getBatteryTemperature(powerInfo: powerInfo) {
             batteryMetrics.batteryTemperature = temp
@@ -212,13 +221,15 @@ class IOKitService {
         return timeToFull
     }
 
-    private func isAdapterConnected() -> Bool {
-        guard let adapterDetails: [String: Any] = getPropertyValue(batteryService, key: "AdapterDetails"),
-              let watts = adapterDetails["Watts"] as? Int else {
-            return false
+    private func getAdapterRatedWatts() -> Int? {
+        guard
+            let adapterDetails: [String: Any] = getPropertyValue(batteryService, key: "AdapterDetails"),
+            let watts = adapterDetails["Watts"] as? Int,
+            watts > 0
+        else {
+            return nil
         }
-
-        return watts > 0
+        return watts
     }
 
     private func getBatteryTemperature(powerInfo: [String: Any]?) -> Double? {
@@ -257,5 +268,76 @@ class IOKitService {
             getPropertyValue(batteryService, key: "DesignCapacity") ?? 0
 
         return (currentCapacity, maxCapacity, designCapacity)
+    }
+
+    private func getSystemInputPowerWatts() -> Double {
+        guard
+            let telemetry: [String: Any] = getPropertyValue(
+                batteryService,
+                key: "PowerTelemetryData"
+            )
+        else {
+            return 0
+        }
+
+        if let systemPowerMilliwatts = telemetry["SystemPowerIn"] as? NSNumber {
+            return max(0, systemPowerMilliwatts.doubleValue / 1000.0)
+        }
+
+        if let systemLoadMilliwatts = telemetry["SystemLoad"] as? NSNumber {
+            return max(0, systemLoadMilliwatts.doubleValue / 1000.0)
+        }
+
+        return 0
+    }
+
+    private func getOutputPowerWatts() -> Double {
+        getOutputPortPowers().reduce(0) { $0 + $1.powerWatts }
+    }
+
+    private func getOutputPortPowers() -> [OutputPortPower] {
+        guard
+            let powerOutDetails: [[String: Any]] = getPropertyValue(
+                batteryService,
+                key: "PowerOutDetails"
+            )
+        else {
+            return []
+        }
+
+        return powerOutDetails.compactMap { detail in
+            guard let portIndex = (detail["PortIndex"] as? NSNumber)?.intValue else {
+                return nil
+            }
+
+            let milliwatts: Double
+            if let wattsMilliwatts = detail["Watts"] as? NSNumber {
+                milliwatts = wattsMilliwatts.doubleValue
+            } else if let currentMilliamps = detail["Current"] as? NSNumber,
+                let voltageMillivolts = detail["AdapterVoltage"] as? NSNumber
+            {
+                milliwatts = currentMilliamps.doubleValue * voltageMillivolts.doubleValue / 1000.0
+            } else {
+                milliwatts = 0
+            }
+
+            let watts = max(0, milliwatts / 1000.0)
+            guard watts > 0.1 else { return nil }
+            return OutputPortPower(portIndex: portIndex, powerWatts: watts)
+        }
+        .sorted { $0.portIndex < $1.portIndex }
+    }
+
+    private func startRefreshLoop() {
+        guard refreshTask == nil else { return }
+        refreshTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .milliseconds(500))
+                guard !Task.isCancelled else { break }
+                await MainActor.run {
+                    self?.emitMetrics()
+                }
+            }
+        }
     }
 }

--- a/Stasis/Services/IOKitService.swift
+++ b/Stasis/Services/IOKitService.swift
@@ -17,6 +17,7 @@ class IOKitService {
         subsystem: "com.srimanachanta.stasis",
         category: "IOKitService"
     )
+    private var outputTelemetryAvailabilityLogged = false
 
     func metricsStream() -> AsyncStream<(BatteryMetrics, AdapterMetrics)> {
         AsyncStream { continuation in
@@ -132,7 +133,6 @@ class IOKitService {
 
         batteryMetrics.externalConnected =
             getPropertyValue(batteryService, key: "ExternalConnected") ?? false
-        batteryMetrics.systemInputPower = getSystemInputPowerWatts()
         batteryMetrics.outputPorts = getOutputPortPowers()
         batteryMetrics.outputPower = batteryMetrics.outputPorts.reduce(0) { $0 + $1.powerWatts }
 
@@ -270,32 +270,11 @@ class IOKitService {
         return (currentCapacity, maxCapacity, designCapacity)
     }
 
-    private func getSystemInputPowerWatts() -> Double {
-        guard
-            let telemetry: [String: Any] = getPropertyValue(
-                batteryService,
-                key: "PowerTelemetryData"
-            )
-        else {
-            return 0
-        }
-
-        if let systemPowerMilliwatts = telemetry["SystemPowerIn"] as? NSNumber {
-            return max(0, systemPowerMilliwatts.doubleValue / 1000.0)
-        }
-
-        if let systemLoadMilliwatts = telemetry["SystemLoad"] as? NSNumber {
-            return max(0, systemLoadMilliwatts.doubleValue / 1000.0)
-        }
-
-        return 0
-    }
-
-    private func getOutputPowerWatts() -> Double {
-        getOutputPortPowers().reduce(0) { $0 + $1.powerWatts }
-    }
-
     private func getOutputPortPowers() -> [OutputPortPower] {
+        guard supportsOutputTelemetry() else {
+            return []
+        }
+
         guard
             let powerOutDetails: [[String: Any]] = getPropertyValue(
                 batteryService,
@@ -326,6 +305,40 @@ class IOKitService {
             return OutputPortPower(portIndex: portIndex, powerWatts: watts)
         }
         .sorted { $0.portIndex < $1.portIndex }
+    }
+
+    private func supportsOutputTelemetry() -> Bool {
+        let osMajor = ProcessInfo.processInfo.operatingSystemVersion.majorVersion
+        guard osMajor >= 26 else {
+            if !outputTelemetryAvailabilityLogged {
+                logger.info("Outgoing output telemetry disabled: requires macOS 26+")
+                outputTelemetryAvailabilityLogged = true
+            }
+            return false
+        }
+
+        let hasTelemetryData: [String: Any]? = getPropertyValue(
+            batteryService,
+            key: "PowerTelemetryData"
+        )
+        let hasPowerOutDetails: [[String: Any]]? = getPropertyValue(
+            batteryService,
+            key: "PowerOutDetails"
+        )
+        let supported = (hasTelemetryData != nil) && (hasPowerOutDetails != nil)
+
+        if !outputTelemetryAvailabilityLogged {
+            if supported {
+                logger.info("Outgoing output telemetry enabled")
+            } else {
+                logger.info(
+                    "Outgoing output telemetry disabled: PowerTelemetryData/PowerOutDetails unavailable"
+                )
+            }
+            outputTelemetryAvailabilityLogged = true
+        }
+
+        return supported
     }
 
     private func startRefreshLoop() {

--- a/Stasis/ViewModels/MenuViewModel.swift
+++ b/Stasis/ViewModels/MenuViewModel.swift
@@ -26,6 +26,9 @@ class MenuViewModel {
     var batteryPower: Double = 0
     var adapterPower: Double = 0
     var systemPower: Double = 0
+    var outputPower: Double = 0
+    var outputPortPowers: [OutputPortPower] = []
+    var outputPortDetailsText: String = "None"
     var powerSource: PowerSource = .battery
     var isCharging: Bool = false
 
@@ -37,6 +40,8 @@ class MenuViewModel {
     private var metricsObservation: Task<Void, Never>?
     private var settingsObservation: Task<Void, Never>?
     private var uptimeTask: Task<Void, Never>?
+    private var stableOutputPorts: [OutputPortPower] = []
+    private var outputPortsHoldUntil: Date = .distantPast
 
     init(batteryService: BatteryService, chargeManager: ChargeManager) {
         self.batteryService = batteryService
@@ -139,7 +144,37 @@ class MenuViewModel {
 
         batteryPower = metrics.batteryPower
         adapterPower = adapter.adapterPower
-        systemPower = adapter.adapterPower - metrics.batteryPower
+        let totalLoadPower: Double = {
+            if adapter.adapterConnected {
+                return max(0, adapter.adapterPower - metrics.batteryPower)
+            }
+            return max(0, -metrics.batteryPower)
+        }()
+        let preferredOutputPower = max(0, metrics.outputPower)
+        let rawOutputPower = preferredOutputPower
+
+        let now = Date()
+        if metrics.outputPorts.isEmpty, now < outputPortsHoldUntil, !stableOutputPorts.isEmpty {
+            outputPortPowers = stableOutputPorts
+        } else {
+            outputPortPowers = metrics.outputPorts
+            if !outputPortPowers.isEmpty {
+                stableOutputPorts = outputPortPowers
+                outputPortsHoldUntil = now.addingTimeInterval(2.5)
+            }
+        }
+
+        let portsOutputPower = outputPortPowers.reduce(0) { $0 + $1.powerWatts }
+        outputPower = min(totalLoadPower, max(portsOutputPower, min(totalLoadPower, rawOutputPower)))
+        systemPower = max(0, totalLoadPower - outputPower)
+
+        if outputPortPowers.isEmpty {
+            outputPortDetailsText = "None"
+        } else {
+            outputPortDetailsText = outputPortPowers
+                .map { "Port \($0.portIndex): \(Int($0.powerWatts.rounded())) W" }
+                .joined(separator: " • ")
+        }
         powerSource = derivedPowerSource
         isCharging = metrics.isCharging
         adapterConnected = adapter.adapterConnected

--- a/Stasis/Views/MenuBuilder.swift
+++ b/Stasis/Views/MenuBuilder.swift
@@ -144,9 +144,33 @@ class MenuBuilder {
                     view: PowerSankeyViewWrapper(viewModel: viewModel)
                 )
             )
+            if shouldShowOutputPortsTextRow {
+                items.append(
+                    createInfoItem(
+                        label: String(localized: "Output Ports"),
+                        keyPath: \.outputPortDetailsText
+                    )
+                )
+            }
         }
 
         return items
+    }
+
+    private var shouldShowOutputPortsTextRow: Bool {
+        guard Defaults[.showOutputPortsText] else {
+            return false
+        }
+        switch Defaults[.outputVisualizationMode] {
+        case .off:
+            return false
+        case .powerOnly:
+            return viewModel.adapterConnected
+        case .batteryOnly:
+            return !viewModel.adapterConnected
+        case .always:
+            return true
+        }
     }
 
     private func buildHardwareSection() -> [NSMenuItem] {
@@ -233,13 +257,30 @@ struct BatteryAdditionalInfoObserverView: View {
 struct PowerSankeyViewWrapper: View {
     let viewModel: MenuViewModel
 
+    private var shouldShowOutput: Bool {
+        switch Defaults[.outputVisualizationMode] {
+        case .off:
+            return false
+        case .powerOnly:
+            return viewModel.adapterConnected
+        case .batteryOnly:
+            return !viewModel.adapterConnected
+        case .always:
+            return true
+        }
+    }
+
     var body: some View {
         PowerSankeyView(
             powerSource: viewModel.powerSource,
             isCharging: viewModel.isCharging,
             batteryPower: viewModel.batteryPower,
             adapterPower: viewModel.adapterPower,
-            systemPower: viewModel.systemPower
+            systemPower: viewModel.systemPower,
+            outputPower: shouldShowOutput ? viewModel.outputPower : 0,
+            outputPortPowers: shouldShowOutput
+                ? viewModel.outputPortPowers.map(\.powerWatts)
+                : []
         )
     }
 }

--- a/Stasis/Views/MenuBuilder.swift
+++ b/Stasis/Views/MenuBuilder.swift
@@ -158,19 +158,7 @@ class MenuBuilder {
     }
 
     private var shouldShowOutputPortsTextRow: Bool {
-        guard Defaults[.showOutputPortsText] else {
-            return false
-        }
-        switch Defaults[.outputVisualizationMode] {
-        case .off:
-            return false
-        case .powerOnly:
-            return viewModel.adapterConnected
-        case .batteryOnly:
-            return !viewModel.adapterConnected
-        case .always:
-            return true
-        }
+        Defaults[.showOutputPortsText]
     }
 
     private func buildHardwareSection() -> [NSMenuItem] {

--- a/Stasis/Views/PowerSankeyView.swift
+++ b/Stasis/Views/PowerSankeyView.swift
@@ -175,6 +175,7 @@ struct PowerSankeyView: View {
     private var rightNodes: some View {
         VStack(spacing: 0) {
             let hasTwoOutputs = outputPortPowers.count >= 2
+            let hasAnyOutput = outputPower > 0
             switch powerSource {
             case .acAdapter:
                 if batteryPower > 0 {
@@ -196,8 +197,6 @@ struct PowerSankeyView: View {
                             value: nil,
                             isLeftSide: false
                         )
-                    } else {
-                        Spacer(minLength: Layout.spacerHeight)
                     }
                 } else {
                     NodeView(
@@ -231,12 +230,13 @@ struct PowerSankeyView: View {
                 .frame(height: Layout.largeNodeHeight)
             case .battery:
                 NodeView(icon: "laptopcomputer", value: nil, isLeftSide: false)
-                if outputPower > 0 {
+                if hasAnyOutput {
+                    Spacer(minLength: Layout.spacerHeight)
                     if hasTwoOutputs {
                         NodeView(icon: "iphone", value: nil, isLeftSide: false)
+                        Spacer(minLength: Layout.spacerHeight)
                         NodeView(icon: "display", value: nil, isLeftSide: false)
                     } else {
-                        Spacer(minLength: Layout.spacerHeight)
                         NodeView(icon: "iphone", value: nil, isLeftSide: false)
                     }
                 }

--- a/Stasis/Views/PowerSankeyView.swift
+++ b/Stasis/Views/PowerSankeyView.swift
@@ -6,6 +6,15 @@ struct PowerSankeyView: View {
     let batteryPower: Double
     let adapterPower: Double
     let systemPower: Double
+    let outputPower: Double
+    let outputPortPowers: [Double]
+
+    private var twoOutputIcons: (first: String, second: String) {
+        guard outputPortPowers.count >= 2 else { return ("iphone", "display") }
+        return outputPortPowers[0] >= outputPortPowers[1]
+            ? ("iphone", "display")
+            : ("display", "iphone")
+    }
 
     private enum Layout {
         static let nodeWidth: CGFloat = 60
@@ -37,21 +46,49 @@ struct PowerSankeyView: View {
 
     @ViewBuilder
     private var flowsAndLabels: some View {
+        let hasAnyOutput = outputPower > 0
+        let hasTwoOutputs = outputPortPowers.count >= 2
         switch powerSource {
         case .acAdapter:
             if batteryPower > 0 {
                 Canvas { context, size in
-                    drawSplitSankeyFlow(context: context, size: size)
+                    if outputPower > 0 {
+                        drawTripleSplitSankeyFlow(context: context, size: size)
+                    } else {
+                        drawSplitSankeyFlow(context: context, size: size)
+                    }
                 }
-                VStack(spacing: Layout.powerLabelSpacing) {
+                VStack(spacing: outputPower > 0 ? 22 : Layout.powerLabelSpacing) {
                     PowerLabel(power: batteryPower)
                     PowerLabel(power: systemPower)
+                    if outputPower > 0 {
+                        PowerLabel(power: outputPower)
+                    }
                 }
             } else {
                 Canvas { context, size in
-                    drawSimpleFlow(context: context, size: size)
+                    if outputPortPowers.count >= 2 {
+                        drawTripleSplitSankeyFlow(context: context, size: size)
+                    } else if outputPower > 0 {
+                        drawSplitSankeyFlow(context: context, size: size)
+                    } else {
+                        drawSimpleFlow(context: context, size: size)
+                    }
                 }
-                PowerLabel(power: adapterPower)
+                if outputPortPowers.count >= 2 {
+                    VStack(spacing: 22) {
+                        PowerLabel(power: systemPower)
+                        PowerLabel(power: outputPortPowers[0])
+                        PowerLabel(power: outputPortPowers[1])
+                    }
+                } else if outputPower > 0 {
+                    VStack(spacing: Layout.powerLabelSpacing) {
+                        PowerLabel(power: systemPower)
+                        PowerLabel(power: outputPower)
+                    }
+                } else {
+                    PowerLabel(power: adapterPower)
+                }
             }
 
         case .both:
@@ -65,15 +102,35 @@ struct PowerSankeyView: View {
 
         case .battery:
             Canvas { context, size in
-                drawSimpleFlow(context: context, size: size)
+                if hasTwoOutputs {
+                    drawTripleSplitSankeyFlow(context: context, size: size)
+                } else if hasAnyOutput {
+                    drawSplitSankeyFlow(context: context, size: size)
+                } else {
+                    drawSimpleFlow(context: context, size: size)
+                }
             }
-            PowerLabel(power: systemPower)
+            if hasTwoOutputs {
+                VStack(spacing: 22) {
+                    PowerLabel(power: systemPower)
+                    PowerLabel(power: outputPortPowers[0])
+                    PowerLabel(power: outputPortPowers[1])
+                }
+            } else if hasAnyOutput {
+                VStack(spacing: Layout.powerLabelSpacing) {
+                    PowerLabel(power: systemPower)
+                    PowerLabel(power: outputPower)
+                }
+            } else {
+                PowerLabel(power: systemPower)
+            }
         }
     }
 
     @ViewBuilder
     private var leftNodes: some View {
-        VStack {
+        let hasAnyOutput = outputPower > 0
+        VStack(spacing: 0) {
             switch powerSource {
             case .acAdapter:
                 if batteryPower > 0 {
@@ -84,25 +141,40 @@ struct PowerSankeyView: View {
                     )
                     .frame(height: Layout.largeNodeHeight)
                 } else {
-                    NodeView(
-                        icon: "powerplug.fill",
-                        value: nil,
-                        isLeftSide: true
-                    )
+                    if hasAnyOutput {
+                        NodeView(
+                            icon: "powerplug.fill",
+                            value: nil,
+                            isLeftSide: true
+                        )
+                        .frame(height: Layout.largeNodeHeight)
+                    } else {
+                        NodeView(
+                            icon: "powerplug.fill",
+                            value: nil,
+                            isLeftSide: true
+                        )
+                    }
                 }
             case .both:
                 NodeView(icon: "battery.100", value: nil, isLeftSide: true)
                 Spacer(minLength: Layout.spacerHeight)
                 NodeView(icon: "powerplug.fill", value: nil, isLeftSide: true)
             case .battery:
-                NodeView(icon: "battery.100", value: nil, isLeftSide: true)
+                if hasAnyOutput {
+                    NodeView(icon: "battery.100", value: nil, isLeftSide: true)
+                        .frame(height: Layout.largeNodeHeight)
+                } else {
+                    NodeView(icon: "battery.100", value: nil, isLeftSide: true)
+                }
             }
         }
     }
 
     @ViewBuilder
     private var rightNodes: some View {
-        VStack {
+        VStack(spacing: 0) {
+            let hasTwoOutputs = outputPortPowers.count >= 2
             switch powerSource {
             case .acAdapter:
                 if batteryPower > 0 {
@@ -117,12 +189,38 @@ struct PowerSankeyView: View {
                         value: nil,
                         isLeftSide: false
                     )
+                    if outputPower > 0 {
+                        Spacer(minLength: Layout.spacerHeight)
+                        NodeView(
+                            icon: "iphone",
+                            value: nil,
+                            isLeftSide: false
+                        )
+                    } else {
+                        Spacer(minLength: Layout.spacerHeight)
+                    }
                 } else {
                     NodeView(
                         icon: "laptopcomputer",
                         value: nil,
                         isLeftSide: false
                     )
+                    if outputPower > 0 {
+                        Spacer(minLength: Layout.spacerHeight)
+                        NodeView(
+                            icon: hasTwoOutputs ? twoOutputIcons.first : "iphone",
+                            value: nil,
+                            isLeftSide: false
+                        )
+                        if hasTwoOutputs {
+                            Spacer(minLength: Layout.spacerHeight)
+                            NodeView(
+                                icon: twoOutputIcons.second,
+                                value: nil,
+                                isLeftSide: false
+                            )
+                        }
+                    }
                 }
             case .both:
                 NodeView(
@@ -133,6 +231,15 @@ struct PowerSankeyView: View {
                 .frame(height: Layout.largeNodeHeight)
             case .battery:
                 NodeView(icon: "laptopcomputer", value: nil, isLeftSide: false)
+                if outputPower > 0 {
+                    if hasTwoOutputs {
+                        NodeView(icon: "iphone", value: nil, isLeftSide: false)
+                        NodeView(icon: "display", value: nil, isLeftSide: false)
+                    } else {
+                        Spacer(minLength: Layout.spacerHeight)
+                        NodeView(icon: "iphone", value: nil, isLeftSide: false)
+                    }
+                }
             }
         }
     }
@@ -189,6 +296,40 @@ struct PowerSankeyView: View {
                 y: size.height / 2 + Layout.largeNodeHeight / 2
             ),
             topRight: CGPoint(x: rightX, y: size.height - smallHeight),
+            bottomRight: CGPoint(x: rightX, y: size.height)
+        )
+    }
+
+    private func drawTripleSplitSankeyFlow(context: GraphicsContext, size: CGSize) {
+        let leftX = Layout.nodeWidth + Layout.gap
+        let rightX = size.width - Layout.nodeWidth - Layout.gap
+
+        let totalGap = Layout.spacerHeight * 2
+        let segmentHeight = (size.height - totalGap) / 3
+        let midY = size.height / 2
+        let leftTop = midY - Layout.largeNodeHeight / 2
+
+        drawTube(
+            context: context,
+            topLeft: CGPoint(x: leftX, y: leftTop),
+            bottomLeft: CGPoint(x: leftX, y: leftTop + Layout.largeNodeHeight / 3),
+            topRight: CGPoint(x: rightX, y: 0),
+            bottomRight: CGPoint(x: rightX, y: segmentHeight)
+        )
+
+        drawTube(
+            context: context,
+            topLeft: CGPoint(x: leftX, y: leftTop + Layout.largeNodeHeight / 3),
+            bottomLeft: CGPoint(x: leftX, y: leftTop + (2 * Layout.largeNodeHeight / 3)),
+            topRight: CGPoint(x: rightX, y: segmentHeight + Layout.spacerHeight),
+            bottomRight: CGPoint(x: rightX, y: (2 * segmentHeight) + Layout.spacerHeight)
+        )
+
+        drawTube(
+            context: context,
+            topLeft: CGPoint(x: leftX, y: leftTop + (2 * Layout.largeNodeHeight / 3)),
+            bottomLeft: CGPoint(x: leftX, y: leftTop + Layout.largeNodeHeight),
+            topRight: CGPoint(x: rightX, y: (2 * segmentHeight) + (2 * Layout.spacerHeight)),
             bottomRight: CGPoint(x: rightX, y: size.height)
         )
     }
@@ -297,12 +438,12 @@ struct NodeView: View {
 }
 
 #Preview {
-    let items: [(PowerSource, Bool, Double, Double, Double)] = [
-        (.both, false, -20.16, 36.0, 56.16),
-        (.acAdapter, true, 20.0, 30.0, 10.0),
-        (.battery, false, -18.63, 0.0, 18.63),
-        (.acAdapter, false, 0.0, 25.0, 25.0),
-        (.acAdapter, false, 23, 39, 16),
+    let items: [(PowerSource, Bool, Double, Double, Double, Double, [Double])] = [
+        (.both, false, -20.16, 36.0, 56.16, 0, []),
+        (.acAdapter, true, 20.0, 30.0, 7.0, 3.0, [3.0]),
+        (.battery, false, -18.63, 0.0, 18.63, 0, []),
+        (.acAdapter, false, 0.0, 25.0, 11.0, 14.0, [9.0, 5.0]),
+        (.acAdapter, false, 23, 39, 16, 0, []),
     ]
     LazyVGrid(
         columns: [
@@ -316,7 +457,9 @@ struct NodeView: View {
                 isCharging: item.1,
                 batteryPower: item.2,
                 adapterPower: item.3,
-                systemPower: item.4
+                systemPower: item.4,
+                outputPower: item.5,
+                outputPortPowers: item.6
             )
             .frame(height: 125)
         }

--- a/Stasis/Views/Settings/DashboardSettingsView.swift
+++ b/Stasis/Views/Settings/DashboardSettingsView.swift
@@ -12,6 +12,8 @@ struct DashboardSettingsView: View {
     @Default(.showInternalPower) var showInternalPower
     @Default(.showExternalPower) var showExternalPower
     @Default(.showPowerDistribution) var showPowerDistribution
+    @Default(.showOutputPortsText) var showOutputPortsText
+    @Default(.outputVisualizationMode) var outputVisualizationMode
 
     var body: some View {
         Form {
@@ -44,6 +46,15 @@ struct DashboardSettingsView: View {
 
             Section("Visuals") {
                 Toggle("Power distribution diagram", isOn: $showPowerDistribution)
+                Picker("Show outgoing output", selection: $outputVisualizationMode) {
+                    Text("Off").tag(OutputVisualizationMode.off)
+                    Text("Power Only").tag(OutputVisualizationMode.powerOnly)
+                    Text("Battery Only").tag(OutputVisualizationMode.batteryOnly)
+                    Text("Always").tag(OutputVisualizationMode.always)
+                }
+                .disabled(!showPowerDistribution)
+                Toggle("Output ports text row", isOn: $showOutputPortsText)
+                    .disabled(!showPowerDistribution || outputVisualizationMode == .off)
             }
         }
         .formStyle(.grouped)

--- a/Stasis/Views/Settings/DashboardSettingsView.swift
+++ b/Stasis/Views/Settings/DashboardSettingsView.swift
@@ -54,7 +54,7 @@ struct DashboardSettingsView: View {
                 }
                 .disabled(!showPowerDistribution)
                 Toggle("Output ports text row", isOn: $showOutputPortsText)
-                    .disabled(!showPowerDistribution || outputVisualizationMode == .off)
+                    .disabled(!showPowerDistribution)
             }
         }
         .formStyle(.grouped)


### PR DESCRIPTION
This pull request adds support for visualizing output power and output ports in the app's power metrics and UI. It introduces new data structures and UI logic to track, compute, and display the power delivered to output ports, including per-port details and visualization controls. The changes affect models, services, view models, and UI components to provide a comprehensive and configurable representation of output power.

**Key changes:**

**1. Output Power and Ports Tracking**
- Added a new `OutputPortPower` struct and associated fields to `BatteryMetrics` to represent and store per-port output power data. [[1]](diffhunk://#diff-6a754f5857dc48d90c9a08d7e91ded0369190a1adf1d2ef8094ffcc88f51cd74R3-R9) [[2]](diffhunk://#diff-6a754f5857dc48d90c9a08d7e91ded0369190a1adf1d2ef8094ffcc88f51cd74R19-R21)
- Updated `IOKitService` to fetch, compute, and emit output power and per-port details using new helper methods (`getOutputPortPowers`, `getSystemInputPowerWatts`, etc.), and to include these in the emitted metrics. [[1]](diffhunk://#diff-481fd6147647fc1e777f63bddc119855c2fb9300c6826c512b55a149f0ff54c7R135-R141) [[2]](diffhunk://#diff-481fd6147647fc1e777f63bddc119855c2fb9300c6826c512b55a149f0ff54c7R272-R342)

**2. Output Power Visualization and UI**
- Enhanced `MenuViewModel` to process, stabilize, and expose output port power data and formatted text for UI display. [[1]](diffhunk://#diff-e5795c27b25b6d9815d8eb7569e2d1eb69a145a0df3e8563a4b6c19112922bffR29-R31) [[2]](diffhunk://#diff-e5795c27b25b6d9815d8eb7569e2d1eb69a145a0df3e8563a4b6c19112922bffL142-R177)
- Updated `PowerSankeyView` and related UI logic to visualize output power and per-port flows, including support for multiple output ports and dynamic Sankey diagram layouts. [[1]](diffhunk://#diff-6090190716dc3957dea830db833ac484e5cf7d6772ce145a2eb6b4a4ddf1120fR9-R17) [[2]](diffhunk://#diff-6090190716dc3957dea830db833ac484e5cf7d6772ce145a2eb6b4a4ddf1120fR49-R92) [[3]](diffhunk://#diff-6090190716dc3957dea830db833ac484e5cf7d6772ce145a2eb6b4a4ddf1120fR105-R133) [[4]](diffhunk://#diff-6090190716dc3957dea830db833ac484e5cf7d6772ce145a2eb6b4a4ddf1120fR143-R177)

**3. User Preferences and Localization**
- Added new user settings for output visualization mode (`OutputVisualizationMode` enum) and for toggling the display of output ports text, with corresponding keys in `DefaultsKeys.swift`. [[1]](diffhunk://#diff-5bdabe8585f494bc0facbc8743e0bcb5ac4b82aaefc27286f343773adb3aceb5R7-R13) [[2]](diffhunk://#diff-5bdabe8585f494bc0facbc8743e0bcb5ac4b82aaefc27286f343773adb3aceb5R40-R44)
- Added new localizable string entries for output visualization options and UI labels. [[1]](diffhunk://#diff-3478e5497afc2cec0f89eb06350fcd18a2dde63350cdb67ba1689e78fe96d584R121-R123) [[2]](diffhunk://#diff-3478e5497afc2cec0f89eb06350fcd18a2dde63350cdb67ba1689e78fe96d584R270-R272) [[3]](diffhunk://#diff-3478e5497afc2cec0f89eb06350fcd18a2dde63350cdb67ba1689e78fe96d584R1386-R1391) [[4]](diffhunk://#diff-3478e5497afc2cec0f89eb06350fcd18a2dde63350cdb67ba1689e78fe96d584R1476-R1478) [[5]](diffhunk://#diff-3478e5497afc2cec0f89eb06350fcd18a2dde63350cdb67ba1689e78fe96d584R1628-R1630)

**4. UI Control Logic**
- Updated `MenuBuilder` and related UI components to conditionally show output ports information and visualization based on user preferences and current power source. [[1]](diffhunk://#diff-6aab32447484fb5b519d42e63354ef75aa264f1f109e3ba6fcac94269eb9eeaaR147-R175) [[2]](diffhunk://#diff-6aab32447484fb5b519d42e63354ef75aa264f1f109e3ba6fcac94269eb9eeaaR260-R283)

**5. Adapter Metrics Improvements**
- Improved adapter metrics tracking by adding `adapterCapacityWatts` and refining logic for determining adapter connection status. [[1]](diffhunk://#diff-6a754f5857dc48d90c9a08d7e91ded0369190a1adf1d2ef8094ffcc88f51cd74R32) [[2]](diffhunk://#diff-481fd6147647fc1e777f63bddc119855c2fb9300c6826c512b55a149f0ff54c7L215-R232)

These changes collectively provide more detailed and configurable output power insights for users, both in the underlying data and in the app's UI.

<img width="346" height="598" alt="Screenshot 2026-05-13 at 5 21 08 PM" src="https://github.com/user-attachments/assets/7c7eb7a2-9639-49dc-8d96-8c1f2ca2bec2" />

> Closes #11 