### PR TITLE
Fix Homebrew install command by removing --no-quarantine flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,11 @@ Stasis gives you real-time insight into your MacBook's power system and lets you
 ### Homebrew (Recommended)
 
 ```bash
-brew install --cask --no-quarantine srimanachanta/tap/stasis
+brew install --cask srimanachanta/tap/stasis
+```
+*If you encounter a macOS quarantine warning, run:*
+```bash
+xattr -dr com.apple.quarantine /Applications/Stasis.app
 ```
 
 ### Direct Download


### PR DESCRIPTION
This pull request updates the installation instructions in the `README.md` to clarify how to handle macOS quarantine warnings when installing Stasis via Homebrew.

Improvements to installation instructions:

* Removed the `--no-quarantine` flag from the Homebrew install command and added guidance for manually removing the quarantine attribute if users encounter a warning.

>Closes #13 