### PR TITLE
feat: reflect Low Power Mode in the menu bar battery icon

### DIFF
--- a/Stasis/StatusBarManager.swift
+++ b/Stasis/StatusBarManager.swift
@@ -49,6 +49,7 @@ struct StatusBarContentView: View {
         BatteryIndicatorView(
             batteryLevel: viewModel.displayPercentage,
             chargingMode: viewModel.chargingMode,
+            isLowPowerModeEnabled: viewModel.isLowPowerModeEnabled,
             showPercentage: showPercentage,
             showState: showState
         )

--- a/Stasis/ViewModels/MenuViewModel.swift
+++ b/Stasis/ViewModels/MenuViewModel.swift
@@ -28,6 +28,7 @@ class MenuViewModel {
     var systemPower: Double = 0
     var powerSource: PowerSource = .battery
     var isCharging: Bool = false
+    var isLowPowerModeEnabled: Bool = ProcessInfo.processInfo.isLowPowerModeEnabled
 
     var chargeLimitOverrideActive: Bool { chargeManager.chargeLimitOverrideActive }
     var forceDischargeActive: Bool { chargeManager.forceDischargeActive }
@@ -37,6 +38,7 @@ class MenuViewModel {
     private var metricsObservation: Task<Void, Never>?
     private var settingsObservation: Task<Void, Never>?
     private var uptimeTask: Task<Void, Never>?
+    private var powerModeObservation: Task<Void, Never>?
 
     init(batteryService: BatteryService, chargeManager: ChargeManager) {
         self.batteryService = batteryService
@@ -44,6 +46,7 @@ class MenuViewModel {
         self.bootTimestamp = SystemService.bootTimestamp()
         startObservingMetrics()
         startObservingSettings()
+        startObservingPowerMode()
     }
 
     private func startObservingMetrics() {
@@ -76,6 +79,17 @@ class MenuViewModel {
                     from: self.batteryService.metrics,
                     adapter: self.batteryService.adapterMetrics
                 )
+            }
+        }
+    }
+
+    private func startObservingPowerMode() {
+        powerModeObservation = Task { [weak self] in
+            guard let self else { return }
+            for await _ in NotificationCenter.default.notifications(
+                named: .NSProcessInfoPowerStateDidChange
+            ) {
+                self.isLowPowerModeEnabled = ProcessInfo.processInfo.isLowPowerModeEnabled
             }
         }
     }

--- a/Stasis/ViewModels/MenuViewModel.swift
+++ b/Stasis/ViewModels/MenuViewModel.swift
@@ -28,7 +28,7 @@ class MenuViewModel {
     var systemPower: Double = 0
     var powerSource: PowerSource = .battery
     var isCharging: Bool = false
-    var isLowPowerModeEnabled: Bool = ProcessInfo.processInfo.isLowPowerModeEnabled
+    var isLowPowerModeEnabled: Bool = false
 
     var chargeLimitOverrideActive: Bool { chargeManager.chargeLimitOverrideActive }
     var forceDischargeActive: Bool { chargeManager.forceDischargeActive }
@@ -84,12 +84,18 @@ class MenuViewModel {
     }
 
     private func startObservingPowerMode() {
+        // Seed the initial value before subscribing so "read + subscribe" live in one place.
+        isLowPowerModeEnabled = ProcessInfo.processInfo.isLowPowerModeEnabled
+
         powerModeObservation = Task { [weak self] in
-            guard let self else { return }
-            for await _ in NotificationCenter.default.notifications(
-                named: .NSProcessInfoPowerStateDidChange
-            ) {
-                self.isLowPowerModeEnabled = ProcessInfo.processInfo.isLowPowerModeEnabled
+            let notifications = NotificationCenter.default.notifications(
+                named: .NSProcessInfoPowerStateDidChange,
+                object: ProcessInfo.processInfo
+            )
+            for await _ in notifications {
+                await MainActor.run {
+                    self?.isLowPowerModeEnabled = ProcessInfo.processInfo.isLowPowerModeEnabled
+                }
             }
         }
     }
@@ -231,6 +237,7 @@ class MenuViewModel {
             metricsObservation?.cancel()
             settingsObservation?.cancel()
             uptimeTask?.cancel()
+            powerModeObservation?.cancel()
         }
     }
 }

--- a/Stasis/ViewModels/MenuViewModel.swift
+++ b/Stasis/ViewModels/MenuViewModel.swift
@@ -84,7 +84,6 @@ class MenuViewModel {
     }
 
     private func startObservingPowerMode() {
-        // Seed the initial value before subscribing so "read + subscribe" live in one place.
         isLowPowerModeEnabled = ProcessInfo.processInfo.isLowPowerModeEnabled
 
         powerModeObservation = Task { [weak self] in
@@ -93,9 +92,7 @@ class MenuViewModel {
                 object: ProcessInfo.processInfo
             )
             for await _ in notifications {
-                await MainActor.run {
-                    self?.isLowPowerModeEnabled = ProcessInfo.processInfo.isLowPowerModeEnabled
-                }
+                self?.isLowPowerModeEnabled = ProcessInfo.processInfo.isLowPowerModeEnabled
             }
         }
     }

--- a/Stasis/Views/BatteryIndicatorView.swift
+++ b/Stasis/Views/BatteryIndicatorView.swift
@@ -3,12 +3,16 @@ import SwiftUI
 struct BatteryIndicatorView: View {
     let batteryLevel: Int
     let chargingMode: ChargingMode
+    var isLowPowerModeEnabled: Bool = false
     var showPercentage: Bool = false
     var showState: Bool = false
 
     private var fillColor: Color {
         if showState && batteryLevel <= 10 {
             return .red
+        }
+        if isLowPowerModeEnabled {
+            return .yellow
         }
         return .primary
     }

--- a/Stasis/Views/BatteryIndicatorView.swift
+++ b/Stasis/Views/BatteryIndicatorView.swift
@@ -130,7 +130,6 @@ struct BatteryTerminal: View {
             .font(.caption)
             .foregroundStyle(.secondary)
 
-        // Low Power Mode enabled — yellow, except critical level stays red
         ForEach([100, 50, 10, 5], id: \.self) { level in
             HStack(spacing: 20) {
                 BatteryIndicatorView(

--- a/Stasis/Views/BatteryIndicatorView.swift
+++ b/Stasis/Views/BatteryIndicatorView.swift
@@ -8,6 +8,7 @@ struct BatteryIndicatorView: View {
     var showState: Bool = false
 
     private var fillColor: Color {
+        // Critical level takes priority over Low Power Mode.
         if showState && batteryLevel <= 10 {
             return .red
         }
@@ -119,6 +120,29 @@ struct BatteryTerminal: View {
                 BatteryIndicatorView(
                     batteryLevel: level,
                     chargingMode: .pluggedIn
+                )
+            }
+        }
+
+        Divider()
+
+        Text("Low Power Mode (yellow; critical red takes priority)")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+
+        // Low Power Mode enabled — yellow, except critical level stays red
+        ForEach([100, 50, 10, 5], id: \.self) { level in
+            HStack(spacing: 20) {
+                BatteryIndicatorView(
+                    batteryLevel: level,
+                    chargingMode: .discharging,
+                    isLowPowerModeEnabled: true,
+                    showState: true
+                )
+                BatteryIndicatorView(
+                    batteryLevel: level,
+                    chargingMode: .charging,
+                    isLowPowerModeEnabled: true
                 )
             }
         }


### PR DESCRIPTION
This pull request adds support for detecting and displaying macOS Low Power Mode status in the battery indicator. The main changes include tracking Low Power Mode in the view model, observing system notifications for changes, and updating the battery indicator's color when Low Power Mode is enabled.

Low Power Mode support:

* Added a new property `isLowPowerModeEnabled` to `MenuViewModel` to track the current Low Power Mode status, and initialized it using `ProcessInfo.processInfo.isLowPowerModeEnabled`.
* Implemented `startObservingPowerMode()` in `MenuViewModel` to listen for `.NSProcessInfoPowerStateDidChange` notifications and update `isLowPowerModeEnabled` accordingly. This ensures the app responds to system changes in Low Power Mode. [[1]](diffhunk://#diff-e5795c27b25b6d9815d8eb7569e2d1eb69a145a0df3e8563a4b6c19112922bffR41-R49) [[2]](diffhunk://#diff-e5795c27b25b6d9815d8eb7569e2d1eb69a145a0df3e8563a4b6c19112922bffR86-R96)

UI updates:

* Updated `StatusBarContentView` to pass the new `isLowPowerModeEnabled` property to `BatteryIndicatorView`, enabling the UI to reflect Low Power Mode status.
* Modified `BatteryIndicatorView` to accept the `isLowPowerModeEnabled` parameter and change the battery fill color to yellow when Low Power Mode is active.

> Closes #14 