### PR TITLE
Implement auto-update functionality and settings integration

### DIFF
--- a/Stasis/AppDelegate.swift
+++ b/Stasis/AppDelegate.swift
@@ -12,8 +12,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     private var chargeManager: ChargeManager!
     private var settingsWindowController: SettingsWindowController!
     private var menu: NSMenu!
+    private let updaterService = UpdaterService.shared
     private var settingsObservation: Task<Void, Never>?
     private var adapterObservation: Task<Void, Never>?
+    private var isMenuOpen = false
+    private var needsMenuRebuild = false
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Exit the app immediately if the device doesn't have a battery
@@ -31,6 +34,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
             await setupServices()
             setupMenu()
             requestNotificationPermissions()
+            updaterService.startIfAvailable()
         }
     }
 
@@ -43,7 +47,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
             chargeManager: chargeManager
         )
         settingsWindowController = SettingsWindowController(
-            capabilities: batteryService.deviceCapabilities)
+            capabilities: batteryService.deviceCapabilities,
+            updaterService: updaterService
+        )
         menuBuilder = MenuBuilder(
             viewModel: viewModel,
             settingsWindowController: settingsWindowController
@@ -65,7 +71,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
                     .showPowerSource, .showTimeTillDischarge, .showBatteryCycleCount,
                     .showBatteryHealth, .showBatteryTemperature, .showUptime,
                     .showBatteryMode, .showInternalPower, .showExternalPower,
-                    .showPowerDistribution, .manageCharging,
+                    .showPowerDistribution,
+                    .manageCharging,
                 ],
                 initial: false
             ) {
@@ -91,7 +98,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     }
 
     private func rebuildMenu() {
+        guard !isMenuOpen else {
+            needsMenuRebuild = true
+            return
+        }
         menuBuilder.populateMenu(menu)
+        needsMenuRebuild = false
     }
 
     private func requestNotificationPermissions() {
@@ -101,10 +113,15 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     }
 
     func menuWillOpen(_ menu: NSMenu) {
+        isMenuOpen = true
         viewModel.menuWillOpen()
     }
 
     func menuDidClose(_ menu: NSMenu) {
+        isMenuOpen = false
+        if needsMenuRebuild {
+            rebuildMenu()
+        }
         viewModel.menuDidClose()
     }
 }

--- a/Stasis/Controllers/SettingsWindowController.swift
+++ b/Stasis/Controllers/SettingsWindowController.swift
@@ -6,9 +6,11 @@ import smc_power
 class SettingsWindowController {
     private var window: NSWindow?
     private let capabilities: DeviceCapabilities
+    private let updaterService: UpdaterService
 
-    init(capabilities: DeviceCapabilities) {
+    init(capabilities: DeviceCapabilities, updaterService: UpdaterService) {
         self.capabilities = capabilities
+        self.updaterService = updaterService
     }
 
     func showSettings() {
@@ -18,7 +20,10 @@ class SettingsWindowController {
             return
         }
 
-        let settingsView = SettingsView(capabilities: capabilities)
+        let settingsView = SettingsView(
+            capabilities: capabilities,
+            updaterService: updaterService
+        )
         let hostingController = NSHostingController(rootView: settingsView)
 
         let newWindow = NSWindow(contentViewController: hostingController)

--- a/Stasis/DefaultsKeys.swift
+++ b/Stasis/DefaultsKeys.swift
@@ -51,3 +51,12 @@ extension Defaults.Keys {
     // Advanced
     static let useHardwarePercentage = Key<Bool>("useHardwarePercentage", default: false)
 }
+
+extension Defaults.Keys {
+    // Updates
+    static let automaticallyCheckForUpdates = Key<Bool>("automaticallyCheckForUpdates", default: true)
+    static let updateAutomationMode = Key<UpdaterService.UpdateAutomationMode>(
+        "updateAutomationMode",
+        default: .notify
+    )
+}

--- a/Stasis/L10n/Localizable.xcstrings
+++ b/Stasis/L10n/Localizable.xcstrings
@@ -7,6 +7,12 @@
     "%lld°C" : {
 
     },
+    "About" : {
+
+    },
+    "About Stasis" : {
+
+    },
     "Adapter" : {
       "localizations" : {
         "de" : {
@@ -122,6 +128,9 @@
     "Approve Stasis in System Settings → Login Items to continue." : {
 
     },
+    "Auto-download to Downloads folder" : {
+
+    },
     "Automatic discharge" : {
       "localizations" : {
         "de" : {
@@ -149,6 +158,9 @@
           }
         }
       }
+    },
+    "Automatically check for updates" : {
+
     },
     "Automatically resume charging when the battery drops below the threshold relative to your charge limit." : {
 
@@ -180,6 +192,9 @@
           }
         }
       }
+    },
+    "Battery and charging control for MacBook." : {
+
     },
     "Battery Health" : {
       "localizations" : {
@@ -353,6 +368,9 @@
 
     },
     "Blinking Orange Slow" : {
+
+    },
+    "Built with a focus on practical battery health and charging workflows." : {
 
     },
     "Charge limit" : {
@@ -638,6 +656,9 @@
         }
       }
     },
+    "Check for updates now" : {
+
+    },
     "Control when Stasis sends you notifications." : {
       "localizations" : {
         "de" : {
@@ -749,6 +770,9 @@
           }
         }
       }
+    },
+    "Developer" : {
+
     },
     "Disable all notifications" : {
       "localizations" : {
@@ -1294,6 +1318,9 @@
         }
       }
     },
+    "Notify only" : {
+
+    },
     "Off" : {
       "localizations" : {
         "de" : {
@@ -1614,6 +1641,9 @@
     "Sleep Prevention" : {
 
     },
+    "Srimana Achanta" : {
+
+    },
     "Startup" : {
       "localizations" : {
         "de" : {
@@ -1641,6 +1671,12 @@
           }
         }
       }
+    },
+    "Stasis" : {
+
+    },
+    "Stasis can check and download updates to your Downloads folder." : {
+
     },
     "Stasis Settings" : {
       "localizations" : {
@@ -1788,6 +1824,9 @@
     "Time until discharge" : {
 
     },
+    "Updates" : {
+
+    },
     "Uptime" : {
       "localizations" : {
         "de" : {
@@ -1849,6 +1888,9 @@
           }
         }
       }
+    },
+    "When updates are found" : {
+
     }
   },
   "version" : "1.1"

--- a/Stasis/L10n/Localizable.xcstrings
+++ b/Stasis/L10n/Localizable.xcstrings
@@ -370,6 +370,9 @@
     "Blinking Orange Slow" : {
 
     },
+    "brew upgrade --cask stasis" : {
+
+    },
     "Built with a focus on practical battery health and charging workflows." : {
 
     },
@@ -1706,6 +1709,9 @@
         }
       }
     },
+    "Stasis was installed via Homebrew Cask. To update, run:" : {
+
+    },
     "Status" : {
       "localizations" : {
         "de" : {
@@ -1825,6 +1831,9 @@
 
     },
     "Updates" : {
+
+    },
+    "Updates managed by Homebrew" : {
 
     },
     "Uptime" : {

--- a/Stasis/Services/UpdaterService.swift
+++ b/Stasis/Services/UpdaterService.swift
@@ -34,17 +34,34 @@ final class UpdaterService: NSObject {
     static let shared = UpdaterService()
     private var isChecking = false
 
+    /// Returns `true` when the app was installed via Homebrew Cask.
+    /// Homebrew manages the update lifecycle for cask-installed apps,
+    /// so the built-in updater should be disabled entirely in this case.
+    static var isHomebrewInstall: Bool {
+        let bundlePath = Bundle.main.bundlePath
+        let homebrewPrefixes = [
+            "/opt/homebrew/Caskroom",   // Apple Silicon default
+            "/usr/local/Caskroom",       // Intel default
+            "/home/linuxbrew/.linuxbrew/Caskroom", // Linux Homebrew
+        ]
+        return homebrewPrefixes.contains { bundlePath.hasPrefix($0) }
+    }
+
     private override init() {
         super.init()
     }
 
     func startIfAvailable() {
+        // Auto-update is disabled for Homebrew installs; Homebrew manages updates.
+        guard !UpdaterService.isHomebrewInstall else { return }
         if Defaults[.automaticallyCheckForUpdates] {
             checkForUpdates(automatic: true)
         }
     }
 
     func checkForUpdates() {
+        // Manual update check is also disabled for Homebrew installs.
+        guard !UpdaterService.isHomebrewInstall else { return }
         checkForUpdates(automatic: false)
     }
 

--- a/Stasis/Services/UpdaterService.swift
+++ b/Stasis/Services/UpdaterService.swift
@@ -1,0 +1,202 @@
+import AppKit
+import Defaults
+import Foundation
+
+@MainActor
+final class UpdaterService: NSObject {
+    enum UpdateAutomationMode: String, CaseIterable, Defaults.Serializable {
+        case notify
+        case autoDownload
+    }
+
+    struct GitHubRelease: Decodable {
+        let tagName: String
+        let htmlUrl: String
+        let assets: [Asset]
+        
+        enum CodingKeys: String, CodingKey {
+            case tagName = "tag_name"
+            case htmlUrl = "html_url"
+            case assets
+        }
+        
+        struct Asset: Decodable {
+            let name: String
+            let browserDownloadUrl: String
+            
+            enum CodingKeys: String, CodingKey {
+                case name
+                case browserDownloadUrl = "browser_download_url"
+            }
+        }
+    }
+
+    static let shared = UpdaterService()
+    private var isChecking = false
+
+    private override init() {
+        super.init()
+    }
+
+    func startIfAvailable() {
+        if Defaults[.automaticallyCheckForUpdates] {
+            checkForUpdates(automatic: true)
+        }
+    }
+
+    func checkForUpdates() {
+        checkForUpdates(automatic: false)
+    }
+
+    private func checkForUpdates(automatic: Bool) {
+        guard !isChecking else { return }
+        isChecking = true
+        
+        Task {
+            defer { isChecking = false }
+            do {
+                let url = URL(string: "https://api.github.com/repos/srimanachanta/Stasis/releases/latest")!
+                var request = URLRequest(url: url)
+                request.setValue("application/vnd.github.v3+json", forHTTPHeaderField: "Accept")
+                
+                let (data, _) = try await URLSession.shared.data(for: request)
+                let release = try JSONDecoder().decode(GitHubRelease.self, from: data)
+                
+                let latestVersion = release.tagName.replacingOccurrences(of: "v", with: "")
+                guard let currentVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String else { return }
+                
+                if latestVersion.compare(currentVersion, options: .numeric) == .orderedDescending {
+                    await handleUpdateFound(release: release, automatic: automatic, currentVersion: currentVersion)
+                } else if !automatic {
+                    await showUpToDateAlert()
+                }
+            } catch {
+                print("Failed to check for updates: \(error)")
+                if !automatic {
+                    await showErrorAlert(error: error)
+                }
+            }
+        }
+    }
+
+    private func handleUpdateFound(release: GitHubRelease, automatic: Bool, currentVersion: String) async {
+        let mode = Defaults[.updateAutomationMode]
+        
+        guard let dmgAsset = release.assets.first(where: { $0.name.hasSuffix(".dmg") }),
+              let downloadURL = URL(string: dmgAsset.browserDownloadUrl) else {
+            // Fallback to opening the release page if no DMG found
+            if mode == .autoDownload || mode == .notify {
+                await showNotifyAlert(releaseURL: URL(string: release.htmlUrl)!, version: release.tagName, currentVersion: currentVersion)
+            }
+            return
+        }
+        
+        if mode == .autoDownload && automatic {
+            await downloadAndNotify(url: downloadURL, version: release.tagName)
+        } else {
+            await showNotifyAlertWithDownload(downloadURL: downloadURL, version: release.tagName, currentVersion: currentVersion)
+        }
+    }
+
+    private func downloadAndNotify(url: URL, version: String) async {
+        do {
+            let downloadsURL = FileManager.default.urls(for: .downloadsDirectory, in: .userDomainMask).first!
+            let destinationURL = downloadsURL.appendingPathComponent("Stasis-\(version).dmg")
+            
+            if FileManager.default.fileExists(atPath: destinationURL.path) {
+                try FileManager.default.removeItem(at: destinationURL)
+            }
+            
+            let (tempURL, _) = try await URLSession.shared.download(from: url)
+            try FileManager.default.moveItem(at: tempURL, to: destinationURL)
+            
+            await showReadyToInstallAlert(dmgURL: destinationURL)
+        } catch {
+            print("Download failed: \(error)")
+            await showErrorAlert(error: error)
+        }
+    }
+
+    private func showUpToDateAlert() async {
+        let alert = NSAlert()
+        alert.messageText = "You're up to date!"
+        alert.informativeText = "Stasis \(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "") is currently the newest version available."
+        alert.alertStyle = .informational
+        alert.addButton(withTitle: "OK")
+        alert.runModal()
+    }
+
+    private func showErrorAlert(error: Error) async {
+        let alert = NSAlert()
+        alert.messageText = "Update Check Failed"
+        alert.informativeText = "Could not check for updates. \(error.localizedDescription)"
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "OK")
+        alert.runModal()
+    }
+
+    private func showNotifyAlert(releaseURL: URL, version: String, currentVersion: String) async {
+        let alert = NSAlert()
+        alert.messageText = "A new version of Stasis is available!"
+        alert.informativeText = "Version \(version) is available (You have \(currentVersion)). Would you like to view the release page?"
+        alert.alertStyle = .informational
+        alert.addButton(withTitle: "View Release")
+        alert.addButton(withTitle: "Cancel")
+        
+        if alert.runModal() == .alertFirstButtonReturn {
+            NSWorkspace.shared.open(releaseURL)
+        }
+    }
+
+    private func showNotifyAlertWithDownload(downloadURL: URL, version: String, currentVersion: String) async {
+        let alert = NSAlert()
+        alert.messageText = "A new version of Stasis is available!"
+        alert.informativeText = "Version \(version) is available (You have \(currentVersion)). Would you like to download it now?"
+        alert.alertStyle = .informational
+        alert.addButton(withTitle: "Download")
+        alert.addButton(withTitle: "Cancel")
+        
+        if alert.runModal() == .alertFirstButtonReturn {
+            await downloadAndNotify(url: downloadURL, version: version)
+        }
+    }
+
+    private func showReadyToInstallAlert(dmgURL: URL) async {
+        let alert = NSAlert()
+        alert.messageText = "Update Downloaded"
+        let command = "xattr -cr /Applications/Stasis.app"
+        
+        alert.informativeText = """
+        Stasis.dmg has been saved to your Downloads folder.
+        
+        To install the update:
+        1. Quit Stasis.
+        2. Open Stasis.dmg and drag Stasis to Applications.
+        3. Run this command in Terminal to bypass Gatekeeper:
+        
+        \(command)
+        """
+        alert.alertStyle = .informational
+        
+        alert.addButton(withTitle: "OK")
+        alert.addButton(withTitle: "Copy Command")
+        alert.addButton(withTitle: "Show in Finder")
+        
+        let response = alert.runModal()
+        
+        if response == .alertSecondButtonReturn {
+            let pasteboard = NSPasteboard.general
+            pasteboard.clearContents()
+            pasteboard.setString(command, forType: .string)
+            
+            // Show a quick notification that it was copied
+            let copiedAlert = NSAlert()
+            copiedAlert.messageText = "Command Copied"
+            copiedAlert.informativeText = "The Terminal command has been copied to your clipboard."
+            copiedAlert.runModal()
+        } else if response == .alertThirdButtonReturn {
+            NSWorkspace.shared.activateFileViewerSelecting([dmgURL])
+        }
+    }
+
+}

--- a/Stasis/Views/Settings/AboutSettingsView.swift
+++ b/Stasis/Views/Settings/AboutSettingsView.swift
@@ -40,24 +40,47 @@ struct AboutSettingsView: View {
                 .padding(.vertical, 2)
             }
 
-            Section {
-                Toggle("Automatically check for updates", isOn: $automaticallyCheckForUpdates)
-
-                Picker("When updates are found", selection: $updateAutomationMode) {
-                    Text("Notify only").tag(UpdaterService.UpdateAutomationMode.notify)
-                    Text("Auto-download to Downloads folder").tag(UpdaterService.UpdateAutomationMode.autoDownload)
-                }
-                .disabled(!automaticallyCheckForUpdates)
-
-                Button("Check for updates now") {
-                    updaterService.checkForUpdates()
-                }
-            } header: {
-                VStack(alignment: .leading, spacing: 2) {
+            if UpdaterService.isHomebrewInstall {
+                Section {
+                    HStack(alignment: .top, spacing: 10) {
+                        Image(systemName: "info.circle")
+                            .foregroundStyle(.secondary)
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("Updates managed by Homebrew")
+                                .fontWeight(.medium)
+                            Text("Stasis was installed via Homebrew Cask. To update, run:")
+                                .foregroundStyle(.secondary)
+                            Text("brew upgrade --cask stasis")
+                                .font(.system(.callout, design: .monospaced))
+                                .padding(.horizontal, 8)
+                                .padding(.vertical, 4)
+                                .background(.quaternary, in: RoundedRectangle(cornerRadius: 6))
+                        }
+                    }
+                    .padding(.vertical, 2)
+                } header: {
                     Text("Updates")
-                    Text("Stasis can check and download updates to your Downloads folder.")
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
+                }
+            } else {
+                Section {
+                    Toggle("Automatically check for updates", isOn: $automaticallyCheckForUpdates)
+
+                    Picker("When updates are found", selection: $updateAutomationMode) {
+                        Text("Notify only").tag(UpdaterService.UpdateAutomationMode.notify)
+                        Text("Auto-download to Downloads folder").tag(UpdaterService.UpdateAutomationMode.autoDownload)
+                    }
+                    .disabled(!automaticallyCheckForUpdates)
+
+                    Button("Check for updates now") {
+                        updaterService.checkForUpdates()
+                    }
+                } header: {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Updates")
+                        Text("Stasis can check and download updates to your Downloads folder.")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
                 }
             }
         }

--- a/Stasis/Views/Settings/AboutSettingsView.swift
+++ b/Stasis/Views/Settings/AboutSettingsView.swift
@@ -1,0 +1,83 @@
+import Defaults
+import SwiftUI
+
+struct AboutSettingsView: View {
+    @Default(.automaticallyCheckForUpdates) var automaticallyCheckForUpdates
+    @Default(.updateAutomationMode) var updateAutomationMode
+
+    private let updaterService: UpdaterService
+
+    init(updaterService: UpdaterService) {
+        self.updaterService = updaterService
+    }
+
+    var body: some View {
+        Form {
+            Section("About Stasis") {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Stasis")
+                        .font(.title3)
+                        .fontWeight(.semibold)
+                    Text("Battery and charging control for MacBook.")
+                        .foregroundStyle(.secondary)
+
+                    if let versionText {
+                        Text(versionText)
+                            .font(.callout)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .padding(.vertical, 2)
+            }
+
+            Section("Developer") {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Srimana Achanta")
+                        .fontWeight(.medium)
+                    Text("Built with a focus on practical battery health and charging workflows.")
+                        .foregroundStyle(.secondary)
+                }
+                .padding(.vertical, 2)
+            }
+
+            Section {
+                Toggle("Automatically check for updates", isOn: $automaticallyCheckForUpdates)
+
+                Picker("When updates are found", selection: $updateAutomationMode) {
+                    Text("Notify only").tag(UpdaterService.UpdateAutomationMode.notify)
+                    Text("Auto-download to Downloads folder").tag(UpdaterService.UpdateAutomationMode.autoDownload)
+                }
+                .disabled(!automaticallyCheckForUpdates)
+
+                Button("Check for updates now") {
+                    updaterService.checkForUpdates()
+                }
+            } header: {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Updates")
+                    Text("Stasis can check and download updates to your Downloads folder.")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .formStyle(.grouped)
+        .scrollContentBackground(.hidden)
+        .contentMargins(.top, 0)
+        .onChange(of: automaticallyCheckForUpdates) { _, _ in
+            // Update check preference saved automatically via Defaults
+        }
+    }
+
+    private var versionText: String? {
+        guard let shortVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String else {
+            return nil
+        }
+
+        return "Version \(shortVersion)"
+    }
+}
+
+#Preview {
+    AboutSettingsView(updaterService: UpdaterService.shared)
+}

--- a/Stasis/Views/Settings/SettingsView.swift
+++ b/Stasis/Views/Settings/SettingsView.swift
@@ -6,6 +6,7 @@ enum SettingsTab: String, CaseIterable, Identifiable {
     case dashboard = "Dashboard"
     case charging = "Charging"
     case advanced = "Advanced"
+    case about = "About"
 
     var id: String { rawValue }
     
@@ -15,6 +16,7 @@ enum SettingsTab: String, CaseIterable, Identifiable {
             case .dashboard: return "Dashboard"
             case .charging: return "Charging"
             case .advanced: return "Advanced"
+            case .about: return "About"
             }
     }
 
@@ -23,11 +25,13 @@ enum SettingsTab: String, CaseIterable, Identifiable {
         case .general:
             return "gearshape"
         case .dashboard:
-            return "chart.xyaxis.line"
+            return "square.grid.2x2"
         case .charging:
             return "battery.100.bolt"
         case .advanced:
-            return "slider.horizontal.3"
+            return "gearshape.2"
+        case .about:
+            return "info.circle"
         }
     }
 }
@@ -36,9 +40,11 @@ struct SettingsView: View {
     @State private var selectedTab: SettingsTab = .general
 
     private let capabilities: DeviceCapabilities
+    private let updaterService: UpdaterService
 
-    init(capabilities: DeviceCapabilities) {
+    init(capabilities: DeviceCapabilities, updaterService: UpdaterService) {
         self.capabilities = capabilities
+        self.updaterService = updaterService
     }
 
     var body: some View {
@@ -64,6 +70,8 @@ struct SettingsView: View {
                     ChargingSettingsView(capabilities: capabilities)
                 case .advanced:
                     AdvancedSettingsView()
+                case .about:
+                    AboutSettingsView(updaterService: updaterService)
                 }
             }
             .navigationTitle(selectedTab.title)
@@ -79,6 +87,7 @@ struct SettingsView: View {
             adapterControl: true,
             hasMagSafe: true,
             magsafeLEDControl: true
-        )
+        ),
+        updaterService: UpdaterService.shared
     )
 }


### PR DESCRIPTION
This pull request introduces a comprehensive update system for Stasis, allowing the app to check for, notify about, and automatically download updates from GitHub. It adds a new `UpdaterService`, integrates update preferences into the settings UI, and expands localization strings to support these features. Additionally, it improves the menu rebuilding logic for better user experience.

**Update System Integration:**

* Added the `UpdaterService` singleton, which checks for updates from GitHub, notifies the user, and can auto-download updates to the Downloads folder based on user preferences. It supports both manual and automatic update checks and handles user interaction for update installation. (`Stasis/Services/UpdaterService.swift`)
* Introduced new user defaults keys for update automation and preferences, enabling persistent control over update behavior. (`Stasis/DefaultsKeys.swift`)
* Added the `AboutSettingsView` to the settings UI, providing controls for update preferences, manual update checks, and displaying version information. (`Stasis/Views/Settings/AboutSettingsView.swift`)
* Updated `SettingsWindowController` and `SettingsView` to include and pass the `UpdaterService` and new About tab. (`Stasis/Controllers/SettingsWindowController.swift`, `Stasis/Views/Settings/SettingsView.swift`) [[1]](diffhunk://#diff-76c50ff845081616f87bf5fa842d1bdddeb49c7fd4d054c06f1df3ceaf495e1aR9-R13) [[2]](diffhunk://#diff-76c50ff845081616f87bf5fa842d1bdddeb49c7fd4d054c06f1df3ceaf495e1aL21-R26) [[3]](diffhunk://#diff-32da93dc7d9640437a00fdd4e819cc9b078ca0a22551128dcbd1b092f439d680R9)

**Localization and UI:**

* Added multiple new localized strings for the update system, About section, and related UI elements. (`Stasis/L10n/Localizable.xcstrings`) [[1]](diffhunk://#diff-3478e5497afc2cec0f89eb06350fcd18a2dde63350cdb67ba1689e78fe96d584R9-R14) [[2]](diffhunk://#diff-3478e5497afc2cec0f89eb06350fcd18a2dde63350cdb67ba1689e78fe96d584R130-R132) [[3]](diffhunk://#diff-3478e5497afc2cec0f89eb06350fcd18a2dde63350cdb67ba1689e78fe96d584R161-R163) [[4]](diffhunk://#diff-3478e5497afc2cec0f89eb06350fcd18a2dde63350cdb67ba1689e78fe96d584R195-R197) [[5]](diffhunk://#diff-3478e5497afc2cec0f89eb06350fcd18a2dde63350cdb67ba1689e78fe96d584R372-R374) [[6]](diffhunk://#diff-3478e5497afc2cec0f89eb06350fcd18a2dde63350cdb67ba1689e78fe96d584R658-R660) [[7]](diffhunk://#diff-3478e5497afc2cec0f89eb06350fcd18a2dde63350cdb67ba1689e78fe96d584R773-R775) [[8]](diffhunk://#diff-3478e5497afc2cec0f89eb06350fcd18a2dde63350cdb67ba1689e78fe96d584R1320-R1322) [[9]](diffhunk://#diff-3478e5497afc2cec0f89eb06350fcd18a2dde63350cdb67ba1689e78fe96d584R1643-R1645) [[10]](diffhunk://#diff-3478e5497afc2cec0f89eb06350fcd18a2dde63350cdb67ba1689e78fe96d584R1674-R1679) [[11]](diffhunk://#diff-3478e5497afc2cec0f89eb06350fcd18a2dde63350cdb67ba1689e78fe96d584R1826-R1828) [[12]](diffhunk://#diff-3478e5497afc2cec0f89eb06350fcd18a2dde63350cdb67ba1689e78fe96d584R1891-R1893)

**Menu Handling Improvements:**

* Improved menu rebuilding logic to defer menu updates while the menu is open, preventing UI inconsistencies, and ensuring the menu is rebuilt when closed if needed. (`Stasis/AppDelegate.swift`) [[1]](diffhunk://#diff-5b652bb649767a8fd5757f5f41075f7f5ebbe54e54f5f8378f0ec03741ca04a6R15-R19) [[2]](diffhunk://#diff-5b652bb649767a8fd5757f5f41075f7f5ebbe54e54f5f8378f0ec03741ca04a6R37) [[3]](diffhunk://#diff-5b652bb649767a8fd5757f5f41075f7f5ebbe54e54f5f8378f0ec03741ca04a6L46-R52) [[4]](diffhunk://#diff-5b652bb649767a8fd5757f5f41075f7f5ebbe54e54f5f8378f0ec03741ca04a6L68-R75) [[5]](diffhunk://#diff-5b652bb649767a8fd5757f5f41075f7f5ebbe54e54f5f8378f0ec03741ca04a6R101-R106) [[6]](diffhunk://#diff-5b652bb649767a8fd5757f5f41075f7f5ebbe54e54f5f8378f0ec03741ca04a6R116-R124)

These changes collectively provide a robust, user-friendly update experience and enhance the overall settings and UI responsiveness.

<img width="812" height="594" alt="Screenshot 2026-05-13 at 6 57 54 PM" src="https://github.com/user-attachments/assets/dccc6218-922b-4684-b865-a11986d624be" />
